### PR TITLE
Update grpcio version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-grpcio==1.10.0
+grpcio>=1.13.0,<2.0.0
+protobuf>=3.5.0.post1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ except ImportError as e:
     def convert(f, _):
         return open(f, 'r').read()
 
-from pydgraph.meta import VERSION
+
+VERSION = None
+
+with open(os.path.join('pydgraph', 'meta.py')) as version_file:
+    exec(version_file.read(), globals())
 
 README = os.path.join(os.path.dirname(__file__), 'README.md')
 


### PR DESCRIPTION
- Update grpcio, since recent version resolve many problems (like gevent compatibility).
- Retrieve version without import `pydgraph` on setup

test on Python 2.7.10 and Python 3.6.5