### PR TITLE
Add test script to use Dgraph test cluster with test ports.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Installs the latest Dgraph from the master branch and runs the 6-node test
+# cluster (3 Zeros, 3 Alphas, replication level 3) whose first Alpha runs on
+# port 9180.
+
+readonly SRCDIR=$(readlink -f ${BASH_SOURCE[0]%/*})
+
+# Install Dgraph
+if [ ! -n "$GOPATH" ]; then
+    echo 'GOPATH not set'
+    exit 1
+fi
+go get -d -v github.com/dgraph-io/dgo
+go get -d -v github.com/dgraph-io/dgraph/dgraph
+
+pushd $GOPATH/src/github.com/dgraph-io/dgraph
+make install
+dgraph version
+popd
+
+# Install dependencies
+pip install -r requirements.txt
+pip install -r coveralls
+
+# Run cluster and tests
+pushd $(dirname $SRCDIR)
+source $GOPATH/src/github.com/dgraph-io/dgraph/contrib/scripts/functions.sh
+restartCluster
+coverage run --source=pydgraph --omit=pydgraph/proto/* setup.py test
+stopCluster
+popd

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -43,8 +43,7 @@ def are_lin_reads_equal(a, b):
     return True
 
 
-SERVER_ADDR = 'localhost:9080'
-
+SERVER_ADDR = 'localhost:9180'
 
 def create_client(addr=SERVER_ADDR):
     return pydgraph.DgraphClient(pydgraph.DgraphClientStub(addr))


### PR DESCRIPTION
* Alpha test port is on 9180.
* test.sh script is ready to run on TeamCity. It builds the latest Dgraph from the master branch, installs the pydgraph dependencies, starts the test cluster, runs the tests, and tears down the test cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/35)
<!-- Reviewable:end -->
