### PR TITLE
Remove linreadmap.

### DIFF
--- a/pydgraph/__init__.py
+++ b/pydgraph/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pydgraph.proto.api_pb2 import Operation, Payload, Request, Response, Mutation, Assigned, TxnContext, Check,\
-    Version, NQuad, Value, Facet, SchemaNode, LinRead, Latency
+    Version, NQuad, Value, Facet, SchemaNode, Latency
 from pydgraph.client_stub import *
 from pydgraph.client import *
 from pydgraph.txn import *

--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -38,7 +38,6 @@ class DgraphClient(object):
             raise ValueError('No clients provided in DgraphClient constructor')
 
         self._clients = clients[:]
-        self._lin_read = api.LinRead()
 
     def alter(self, operation, timeout=None, metadata=None, credentials=None):
         """Runs a modification via this client."""
@@ -55,14 +54,6 @@ class DgraphClient(object):
     def txn(self):
         """Creates a transaction."""
         return txn.Txn(self)
-
-    def set_lin_read(self, ctx):
-        """Sets linread map in ctx to the one from this instace."""
-        ctx.lin_read.MergeFrom(self._lin_read)
-
-    def merge_lin_reads(self, src):
-        """Merges linread map in this instance with src."""
-        util.merge_lin_reads(self._lin_read, src)
 
     def any_client(self):
         """Returns a random client."""

--- a/pydgraph/util.py
+++ b/pydgraph/util.py
@@ -24,22 +24,6 @@ __version__ = VERSION
 __status__ = 'development'
 
 
-def merge_lin_reads(target, src):
-    """Merger src linread map into target linread map."""
-    if src is None:
-        return target
-
-    # cache for the loop
-    target_ids = target.ids
-    target_ids_get = target_ids.get
-
-    for key, src_value in src.ids.items():
-        if target_ids_get(key, 0) <= src_value:
-            target_ids[key] = src_value
-
-    return target
-
-
 def is_string(string):
     """Checks if argument is a string. Compatible with Python 2 and 3."""
     if sys.version_info[0] < 3:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -22,31 +22,6 @@ import unittest
 import pydgraph
 
 
-def create_lin_read(src_ids):
-    """Creates a linread map using src_ids."""
-    lin_read = pydgraph.LinRead()
-    ids = lin_read.ids
-    for key, value in src_ids.items():
-        ids[key] = value
-
-    return lin_read
-
-
-def are_lin_reads_equal(lin_read1, lin_read2):
-    """Returns True if both linread maps are equal."""
-    ids1 = lin_read1.ids
-    ids2 = lin_read2.ids
-
-    if len(ids1) != len(ids2):
-        return False
-
-    for (key, value) in ids1.items():
-        if key not in ids2 or lin_read2.ids[key] != value:
-            return False
-
-    return True
-
-
 SERVER_ADDR = 'localhost:9180'
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -25,56 +25,6 @@ import pydgraph
 from . import helper
 
 
-class TestMergeLinReads(unittest.TestCase):
-    """Tests merge_lin_reads utility function."""
-
-    def common_test(self, lr1, lr2, expected):
-        self.assertTrue(helper.are_lin_reads_equal(util.merge_lin_reads(lr1, lr2), expected))
-        self.assertTrue(helper.are_lin_reads_equal(lr1, expected))
-
-    def test_disjoint(self):
-        lr1 = helper.create_lin_read({1: 1})
-        lr2 = helper.create_lin_read({2: 2, 3: 3})
-        res = helper.create_lin_read({1: 1, 2: 2, 3: 3})
-        self.common_test(lr1, lr2, res)
-
-    def test_lower_value(self):
-        lr1 = helper.create_lin_read({1: 2})
-        lr2 = helper.create_lin_read({1: 1})
-        res = helper.create_lin_read({1: 2})
-        self.common_test(lr1, lr2, res)
-
-    def test_higher_value(self):
-        lr1 = helper.create_lin_read({1: 1})
-        lr2 = helper.create_lin_read({1: 2})
-        res = helper.create_lin_read({1: 2})
-        self.common_test(lr1, lr2, res)
-
-    def test_equal_value(self):
-        lr1 = helper.create_lin_read({1: 1})
-        lr2 = helper.create_lin_read({1: 1})
-        res = helper.create_lin_read({1: 1})
-        self.common_test(lr1, lr2, res)
-
-    def test_none(self):
-        lr1 = helper.create_lin_read({1: 1})
-        lr2 = None
-        res = helper.create_lin_read({1: 1})
-        self.common_test(lr1, lr2, res)
-
-    def test_no_src_ids(self):
-        lr1 = helper.create_lin_read({1: 1})
-        lr2 = pydgraph.LinRead()
-        res = helper.create_lin_read({1: 1})
-        self.common_test(lr1, lr2, res)
-
-    def test_no_target_ids(self):
-        lr1 = pydgraph.LinRead()
-        lr2 = helper.create_lin_read({1: 1})
-        res = helper.create_lin_read({1: 1})
-        self.common_test(lr1, lr2, res)
-
-
 class TestIsString(unittest.TestCase):
     """Tests is_string utility function."""
 
@@ -88,7 +38,6 @@ class TestIsString(unittest.TestCase):
 def suite():
     """Returns a test suite object."""
     suite_obj = unittest.TestSuite()
-    suite_obj.addTest(TestMergeLinReads())
     suite_obj.addTest(TestIsString())
     return suite_obj
 


### PR DESCRIPTION
linreadmap was removed from Dgraph and is no longer needed in clients.

Addresses #33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/39)
<!-- Reviewable:end -->
