### PR TITLE
Add support for read-only transactions.

### DIFF
--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -52,9 +52,9 @@ class DgraphClient(object):
         return self.txn().query(query, variables=variables, timeout=timeout,
                                 metadata=metadata, credentials=credentials)
 
-    def txn(self):
+    def txn(self, read_only=False):
         """Creates a transaction."""
-        return txn.Txn(self)
+        return txn.Txn(self, read_only=read_only)
 
     def set_lin_read(self, ctx):
         """Sets linread map in ctx to the one from this instace."""

--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -49,8 +49,9 @@ class DgraphClient(object):
     def query(self, query, variables=None, timeout=None, metadata=None,
               credentials=None):
         """Runs a query via this client."""
-        return self.txn().query(query, variables=variables, timeout=timeout,
-                                metadata=metadata, credentials=credentials)
+        txn = self.txn(read_only=True)
+        return txn.query(query, variables=variables, timeout=timeout,
+                         metadata=metadata, credentials=credentials)
 
     def txn(self, read_only=False):
         """Creates a transaction."""

--- a/pydgraph/txn.py
+++ b/pydgraph/txn.py
@@ -42,13 +42,14 @@ class Txn(object):
     after calling commit.
     """
 
-    def __init__(self, client):
+    def __init__(self, client, read_only=False):
         self._dc = client
         self._ctx = api.TxnContext()
         self._dc.set_lin_read(self._ctx)
 
         self._finished = False
         self._mutated = False
+        self._read_only = read_only
         self._sequencing = api.LinRead.CLIENT_SIDE
 
     def sequencing(self, sequencing):
@@ -73,7 +74,7 @@ class Txn(object):
         lin_read = self._ctx.lin_read
         lin_read.sequencing = self._sequencing
         req = api.Request(query=query, start_ts=self._ctx.start_ts,
-                          lin_read=lin_read)
+                          lin_read=lin_read, read_only=self._read_only)
         if variables is not None:
             for key, value in variables.items():
                 if util.is_string(key) and util.is_string(value):
@@ -113,6 +114,12 @@ class Txn(object):
     def _common_mutate(self, mutation=None, set_obj=None, del_obj=None,
                        set_nquads=None, del_nquads=None,
                        commit_now=None, ignore_index_conflict=None):
+        if self._read_only:
+            raise Exception(
+                'Readonly transaction cannot run mutations or be committed')
+        if self._finished:
+            raise Exception(
+                'Transaction has already been committed or discarded')
         if not mutation:
             mutation = api.Mutation()
         if set_obj:
@@ -127,10 +134,6 @@ class Txn(object):
             mutation.commit_now = True
         if ignore_index_conflict:
             mutation.ignore_index_conflict = True
-
-        if self._finished:
-            raise Exception(
-                'Transaction has already been committed or discarded')
 
         self._mutated = True
         mutation.start_ts = self._ctx.start_ts
@@ -160,6 +163,9 @@ class Txn(object):
             self._common_except_commit(error)
 
     def _common_commit(self):
+        if self._read_only:
+            raise Exception(
+                'Readonly transaction cannot run mutations or be committed')
         if self._finished:
             raise Exception(
                 'Transaction has already been committed or discarded')

--- a/tests/test_txn.py
+++ b/tests/test_txn.py
@@ -232,7 +232,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
 
     def test_read_only_txn(self):
         """Tests read-only transactions. Read-only transactions should
-        not advance the start ts, nor should mutations or commits be
+        not advance the start ts nor should mutations or commits be
         allowed."""
 
         query = '{ me() {} }'

--- a/tests/test_txn.py
+++ b/tests/test_txn.py
@@ -230,6 +230,33 @@ class TestTxn(helper.ClientIntegrationTestCase):
         resp = self.client.query(query)
         self.assertEqual([{'name': 'Manish2'}], json.loads(resp.json).get('me'))
 
+    def test_read_only_txn(self):
+        """Tests read-only transactions. Read-only transactions should
+        not advance the start ts, nor should mutations or commits be
+        allowed."""
+
+        query = '{ me() {} }'
+
+        # Using client.query helper method
+        resp1 = self.client.query(query)
+        start_ts1 = resp1.txn.start_ts
+        resp2 = self.client.query(query)
+        start_ts2 = resp2.txn.start_ts
+        self.assertEqual(start_ts1, start_ts2)
+
+        # Using client.txn method
+        txn = self.client.txn(read_only=True)
+        resp1 = txn.query(query)
+        start_ts1 = resp1.txn.start_ts
+        resp2 = txn.query(query)
+        start_ts2 = resp2.txn.start_ts
+        self.assertEqual(start_ts1, start_ts2)
+
+        with self.assertRaises(Exception):
+            txn.mutate(set_obj={'name': 'Manish'})
+        with self.assertRaises(Exception):
+            txn.commit()
+
     def test_conflict(self):
         """Tests committing two transactions which conflict."""
 

--- a/tests/test_txn.py
+++ b/tests/test_txn.py
@@ -232,8 +232,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
 
     def test_read_only_txn(self):
         """Tests read-only transactions. Read-only transactions should
-        not advance the start ts nor should mutations or commits be
-        allowed."""
+        not advance the start ts nor should allow mutations or commits."""
 
         query = '{ me() {} }'
 


### PR DESCRIPTION
Read-only transactions can be created by using `client.txn(read_only=True)` instead of `client.txn()`. Read-only transactions improve performance of queries by not going through the Raft proposal system when advancing the start ts. The start ts stays the same across the lifetime of the transaction. Mutations and commits are not allowed in read-only transactions.

The `client.query` helper method uses read-only transactions now. This addresses #27.

Closes #30.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/40)
<!-- Reviewable:end -->
