### PR TITLE
Remove query method from client.py

### DIFF
--- a/examples/simple/simple.py
+++ b/examples/simple/simple.py
@@ -99,7 +99,7 @@ def delete_data(client):
             }   
         }"""
         variables1 = {'$a': 'Bob'}
-        res1 = client.query(query1, variables=variables1)
+        res1 = client.txn(read_only=True).query(query1, variables=variables1)
         ppl1 = json.loads(res1.json)
         for person in ppl1['all']:
             print('Query to find Uid for Bob :')
@@ -142,7 +142,7 @@ def query_data(client):
     }"""
 
     variables = {'$a': 'Alice'}
-    res = client.query(query, variables=variables)
+    res = client.txn(read_only=True).query(query, variables=variables)
     ppl = json.loads(res.json)
 
     # Print results.
@@ -178,7 +178,7 @@ def query_data01(client):
         }"""
 
     variables01 = {'$b': 'Bob'}
-    res01 = client.query(query01, variables=variables01)
+    res01 = client.txn(read_only=True).query(query01, variables=variables01)
     ppl01 = json.loads(res01.json)
 
     print('Number of people named "Bob": {}'.format(len(ppl01['all'])))

--- a/examples/tls/mutualtls_example.py
+++ b/examples/tls/mutualtls_example.py
@@ -48,7 +48,7 @@ url: string .
         txn.discard()
     
     # Query
-    res = client.query('''
+    res = client.txn(read_only=True).query('''
 query dgraph($name: string) {
   data(func: eq(name, $name)) {
     uid

--- a/examples/tls/mutualtls_example.py
+++ b/examples/tls/mutualtls_example.py
@@ -46,7 +46,7 @@ url: string .
         txn.commit()
     finally:
         txn.discard()
-    
+
     # Query
     res = client.txn(read_only=True).query('''
 query dgraph($name: string) {

--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -86,25 +86,6 @@ class DgraphClient(object):
             else:
                 raise error
 
-
-    def query(self, query, variables=None, timeout=None, metadata=None,
-              credentials=None):
-        """Runs a query via this client."""
-        new_metadata = self.add_login_metadata(metadata)
-        txn = self.txn(read_only=True)
-
-        try:
-            return txn.query(query, variables=variables, timeout=timeout,
-                             metadata=new_metadata, credentials=credentials)
-        except Exception as error:
-            if util.is_jwt_expired(error):
-                self.retry_login()
-                new_metadata = self.add_login_metadata(metadata)
-                return txn.query(query, variables=variables, timeout=timeout,
-                                 metadata=new_metadata, credentials=credentials)
-            else:
-                raise error
-
     def txn(self, read_only=False, best_effort=False):
         """Creates a transaction."""
         return txn.Txn(self, read_only=read_only, best_effort=best_effort)

--- a/tests/test_acct_upsert.py
+++ b/tests/test_acct_upsert.py
@@ -89,7 +89,7 @@ class TestAccountUpsert(helper.ClientIntegrationTestCase):
             }}
         }}""".format(' '.join(firsts))
         logging.debug(query)
-        result = json.loads(self.client.query(query).json)
+        result = json.loads(self.client.txn(read_only=True).query(query).json)
 
         account_set = set()
         for acct in result['all']:

--- a/tests/test_essentials.py
+++ b/tests/test_essentials.py
@@ -31,7 +31,7 @@ class TestEssentials(helper.ClientIntegrationTestCase):
         """Tests what happens when making a mutation on a txn after querying
         on the client."""
 
-        _ = self.client.query('{firsts(func: has(first)) { uid first }}')
+        _ = self.client.txn(read_only=True).query('{firsts(func: has(first)) { uid first }}')
 
         txn = self.client.txn()
         mutation = txn.mutate(set_nquads='_:node <first> "Node name first" .')
@@ -43,7 +43,7 @@ class TestEssentials(helper.ClientIntegrationTestCase):
         txn.commit()
 
         query = '{{node(func: uid({uid:s})) {{ uid }} }}'.format(uid=created)
-        reread = self.client.query(query)
+        reread = self.client.txn(read_only=True).query(query)
         self.assertEqual(created, json.loads(reread.json).get('node')[0]['uid'])
 
 

--- a/tests/test_essentials.py
+++ b/tests/test_essentials.py
@@ -28,8 +28,7 @@ class TestEssentials(helper.ClientIntegrationTestCase):
     """Tests mutation after query behavior."""
 
     def testMutationAfterQuery(self):
-        """Tests what happens when making a mutation on a txn after querying
-        on the client."""
+        """Tests what happens when making a mutation on a txn after querying."""
 
         _ = self.client.txn(read_only=True).query('{firsts(func: has(first)) { uid first }}')
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -57,7 +57,7 @@ class TestQueries(helper.ClientIntegrationTestCase):
             }
         }"""
 
-        response = self.client.query(query, variables={'$a': 'Alice'})
+        response = self.client.txn().query(query, variables={'$a': 'Alice'})
         self.assertEqual([{'name': 'Alice', 'follows': [{'name': 'Greg'}]}],
                          json.loads(response.json).get('me'))
         self.assertTrue(is_number(response.latency.parsing_ns),

--- a/tests/test_txn.py
+++ b/tests/test_txn.py
@@ -236,14 +236,12 @@ class TestTxn(helper.ClientIntegrationTestCase):
 
         query = '{ me() {} }'
 
-        # Using client.query helper method
         resp1 = self.client.txn(read_only=True).query(query)
         start_ts1 = resp1.txn.start_ts
         resp2 = self.client.txn(read_only=True).query(query)
         start_ts2 = resp2.txn.start_ts
         self.assertEqual(start_ts1, start_ts2)
 
-        # Using client.txn method
         txn = self.client.txn(read_only=True)
         resp1 = txn.query(query)
         start_ts1 = resp1.txn.start_ts

--- a/tests/test_txn.py
+++ b/tests/test_txn.py
@@ -75,7 +75,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
                 name
             }}
         }}""".format(uid=uid)
-        resp = self.client.query(query)
+        resp = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Manish'}], json.loads(resp.json).get('me'))
 
     def test_discard(self):
@@ -98,7 +98,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
                 name
             }}
         }}""".format(uid=uid)
-        resp = self.client.query(query)
+        resp = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Manish'}], json.loads(resp.json).get('me'))
 
     def test_mutate_error(self):
@@ -143,7 +143,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
             }}
         }}""".format(uid=uid)
 
-        resp = self.client.query(query)
+        resp = self.client.txn(read_only=True).query(query)
         self.assertEqual([], json.loads(resp.json).get('me'))
 
     def test_read_after_start_ts(self):
@@ -163,7 +163,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
             }}
         }}""".format(uid=uid)
 
-        resp = self.client.query(query)
+        resp = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Manish'}], json.loads(resp.json).get('me'))
 
     def test_read_before_and_after_start_ts(self):
@@ -197,7 +197,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
         # once txn3 is committed, other txns observe the update
         txn3.commit()
 
-        resp4 = self.client.query(query)
+        resp4 = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Manish2'}], json.loads(resp4.json).get('me'))
 
     def test_read_from_new_client(self):
@@ -218,7 +218,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
             }}
         }}""".format(uid=uid)
 
-        resp2 = client2.query(query)
+        resp2 = client2.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Manish'}], json.loads(resp2.json).get('me'))
         self.assertTrue(resp2.txn.start_ts > 0)
 
@@ -227,7 +227,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
         self.assertTrue(assigned.context.start_ts > 0)
         txn2.commit()
 
-        resp = self.client.query(query)
+        resp = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Manish2'}], json.loads(resp.json).get('me'))
 
     def test_read_only_txn(self):
@@ -237,9 +237,9 @@ class TestTxn(helper.ClientIntegrationTestCase):
         query = '{ me() {} }'
 
         # Using client.query helper method
-        resp1 = self.client.query(query)
+        resp1 = self.client.txn(read_only=True).query(query)
         start_ts1 = resp1.txn.start_ts
-        resp2 = self.client.query(query)
+        resp2 = self.client.txn(read_only=True).query(query)
         start_ts2 = resp2.txn.start_ts
         self.assertEqual(start_ts1, start_ts2)
 
@@ -361,7 +361,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
             }}
         }}""".format(uid=uid)
 
-        resp4 = self.client.query(query)
+        resp4 = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'name': 'Jan the man'}], json.loads(resp4.json).get('me'))
 
     def test_mutate_conflict(self):
@@ -408,7 +408,7 @@ class TestTxn(helper.ClientIntegrationTestCase):
             }
         }"""
 
-        resp = self.client.query(query)
+        resp = self.client.txn(read_only=True).query(query)
         self.assertEqual([{'uid': uid1}, {'uid': uid2}], json.loads(resp.json).get('me'))
 
     def test_read_index_key_same_txn(self):


### PR DESCRIPTION
Other clients do not have the query as part of the client interface,
only the transaction interface can do that. This change removes query
from the client interface so that it matches the rest of the clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/61)
<!-- Reviewable:end -->
