### PR TITLE
Free GRPC resources on stub close

### DIFF
--- a/pydgraph/client_stub.py
+++ b/pydgraph/client_stub.py
@@ -70,5 +70,9 @@ class DgraphClientStub(object):
 
     def close(self):
         """Deletes channel and stub."""
+        try:
+            self.channel.close()
+        except:
+            pass
         del self.channel
         del self.stub


### PR DESCRIPTION
Lastest versions of GRPC does not include the shutdown and destroy channel on _del_ call. (https://github.com/grpc/grpc/issues/12531).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/69)
<!-- Reviewable:end -->
