### PR TITLE
Don't pin dependency versions in requirements.txt (#70)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 grpcio>=1.18.0
-protobuf==3.6.1
+protobuf>=3.6.1


### PR DESCRIPTION
As per #70, this PR changes the `protobuf` dependency from `==3.6.1` to `>=3.6.1`.

Closes #70

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/71)
<!-- Reviewable:end -->
