### PR TITLE
Catch pypandoc ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,13 @@ except ImportError as e:
 
     def convert_file(f, _):
         return open(f, 'r').read()
+except ModuleNotFoundError as e:
+    # NOTE: error is thrown only for package build steps
+    if 'sdist' in sys.argv or 'bdist_wheel' in sys.argv:
+        raise e
+
+    def convert_file(f, _):
+        return open(f, 'r').read()
 
 from pydgraph.meta import VERSION
 


### PR DESCRIPTION
Python >= 3.6 doesn't receive ImportError, but instead
ModuleNotFoundError.

I haven't performed exhaustive testing, apart from confirming that the following pattern works on Python 2.7:

```python
try:
    import foobar
except ImportError:
    print 'OK'
except ModuleNotFoundError:
    print 'Never reached on Python 2.7'
```

I also didn't want to "dry" up the duplicated code since it's short and contains a function definition on the top level scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/81)
<!-- Reviewable:end -->
