### PR TITLE
Do not throw errors in build steps if pypandoc is not found.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,17 +23,9 @@ except ImportError:
 try:
     from pypandoc import convert_file
 except ImportError as e:
-    # NOTE: error is thrown only for package build steps
-    if 'sdist' in sys.argv or 'bdist_wheel' in sys.argv:
-        raise e
-
     def convert_file(f, _):
         return open(f, 'r').read()
 except ModuleNotFoundError as e:
-    # NOTE: error is thrown only for package build steps
-    if 'sdist' in sys.argv or 'bdist_wheel' in sys.argv:
-        raise e
-
     def convert_file(f, _):
         return open(f, 'r').read()
 


### PR DESCRIPTION
Throwing this error is causing issues for users that try to build
packages that depend on pydgraph.

See https://github.com/dgraph-io/pydgraph/issues/82 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/84)
<!-- Reviewable:end -->
