### PR TITLE
Add a note about version compatibility in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Install using pip:
 pip install pydgraph
 ```
 
+**NOTE**: Dgraph 1.1.x and 1.0.x have incompatible APIs. 1.1.x is supported by
+versions of pydgraph >=2 while 1.0.x is supported by versions <= 1.2.0.
+
 ## Quickstart
 
 Build and run the [simple][] project in the `examples` folder, which


### PR DESCRIPTION
Versions of pydgraph >= 2 don't work with Dgraph 1.0.x and viceversa.
This PR adds a note in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/88)
<!-- Reviewable:end -->
