### PR TITLE
Change simple example to connect to Dgraph's default port.

### DIFF
--- a/examples/simple/simple.py
+++ b/examples/simple/simple.py
@@ -6,7 +6,7 @@ import pydgraph
 
 # Create a client stub.
 def create_client_stub():
-    return pydgraph.DgraphClientStub('localhost:9180')
+    return pydgraph.DgraphClientStub('localhost:9080')
 
 
 # Create a client.


### PR DESCRIPTION
The simple.py [README.md](https://github.com/dgraph-io/pydgraph/blob/326a5b7d5a66f03162dce288a82f99f069c90d46/examples/simple/README.md) configures the Dgraph cluster with the default ports, so simple.py should connect to port 9080.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/93)
<!-- Reviewable:end -->
