### PR TITLE
Expose check_version client call.

### DIFF
--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -41,6 +41,28 @@ class DgraphClient(object):
         self._jwt = api.Jwt()
         self._login_metadata = []
 
+    def check_version(self, timeout=None, metadata=None, credentials=None):
+        """Returns the version of Dgraph if the server is ready to accept requests."""
+
+        new_metadata = self.add_login_metadata(metadata)
+        check_req = api.Check()
+
+        try:
+            response = self.any_client().check_version(check_req, timeout=timeout,
+                                                       metadata=new_metadata,
+                                                       credentials=credentials)
+            return response.tag
+        except Exception as error:
+            if util.is_jwt_expired(error):
+                self.retry_login()
+                new_metadata = self.add_login_metadata(metadata)
+                response = self.any_client().check_version(check_req, timeout=timeout,
+                                                   metadata=new_metadata,
+                                                   credentials=credentials)
+                return response.tag
+            else:
+                raise error
+
     def login(self, userid, password, timeout=None, metadata=None,
               credentials=None):
         login_req = api.LoginRequest()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -36,6 +36,18 @@ class TestQueries(helper.ClientIntegrationTestCase):
         helper.drop_all(self.client)
         helper.set_schema(self.client, 'name: string @index(term) .')
 
+    def test_check_version(self):
+        """Verifies the check_version method correctly returns the cluster version"""
+        success = 0
+        for i in range(3):
+            try:
+                tag = self.client.check_version()
+                self.assertGreater(len(tag), 0)
+                success += 1
+            except Exception as e:
+                continue
+        self.assertGreater(success, 0)
+
     def test_mutation_and_query(self):
         """Runs mutation and verifies queries see the results."""
 


### PR DESCRIPTION
The check_version call is in the client_stub but has not been exposed
in the client.

Fixes #128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/131)
<!-- Reviewable:end -->
