### PR TITLE
Fix missing import of 'errors'

### DIFF
--- a/pydgraph/client.py
+++ b/pydgraph/client.py
@@ -16,7 +16,7 @@
 
 import random
 
-from pydgraph import txn, util
+from pydgraph import errors, txn, util
 from pydgraph.meta import VERSION
 from pydgraph.proto import api_pb2 as api
 


### PR DESCRIPTION
Fixes issue from Discuss: https://discuss.dgraph.io/t/client-py-does-not-import-errors/9271

The `errors` module has been used without importing it first, I've added the required import statement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/151)
<!-- Reviewable:end -->
