### PR TITLE
Docs (discuss feedback): fix incorrect statement about upsert blocks allowing one query and one mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install pydgraph
 
 ### Install Notes
 
-To avoid issues when adding composite credentials or when using client authorization, please install gRPC version 1.19.0: 
+To avoid issues when adding composite credentials or when using client authorization, please install gRPC version 1.19.0:
 
 ```sh
 pip install grpcio==1.19.0
@@ -300,10 +300,12 @@ txn.do_request(request)
 
 ### Running an Upsert: Query + Mutation
 
-The `txn.do_request` function allows you to run upserts consisting of one query and
-one mutation. Query variables could be defined and can then be used in the mutation.
+The `txn.do_request` function allows you to use upsert blocks consisting of one
+query block and one mutation block. Query variables can be defined and can then
+be used in the mutation.
 
-To know more about upsert, we highly recommend going through the [mutations docs](https://docs.dgraph.io/mutations/#upsert-block).
+To learn more about upsert blocks, see the
+[Upsert Block docs](https://dgraph.io/docs/mutations/upsert-block/).
 
 ```python
 query = """{

--- a/README.md
+++ b/README.md
@@ -300,12 +300,14 @@ txn.do_request(request)
 
 ### Running an Upsert: Query + Mutation
 
-The `txn.do_request` function allows you to use upsert blocks consisting of one
-query block and one mutation block. Query variables can be defined and can then
-be used in the mutation.
+The `txn.do_request` function allows you to use upsert blocks. An upsert block
+contains one query block and one or more mutation blocks, so it lets you perform
+queries and mutations in a single request. Variables defined in the query block
+can be used in the mutation blocks using the `uid` and `val` functions
+implemented by DQL.
 
 To learn more about upsert blocks, see the
-[Upsert Block docs](https://dgraph.io/docs/mutations/upsert-block/).
+[Upsert Block documentation](https://dgraph.io/docs/mutations/upsert-block/).
 
 ```python
 query = """{


### PR DESCRIPTION
Fixes the incorrect statement in the PR title, per DGRAPH-2777 and https://discuss.dgraph.io/t/f-strings-vs-variables/11606/3

* Some rewording in this section
* Clarification about what upsert blocks are and how to use them
* Updated a deprecated URL pointing to upsert block docs

On-hold pending resolution of TeamCity build errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/161)
<!-- Reviewable:end -->
