### PR TITLE
fix - Refresh example for v21.03.x

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -24,7 +24,7 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=server:7080 --lru_mb=2048 --zero=zero:5080 --whitelist "${WHITELISTED}"
+    command: dgraph alpha --my=server:7080 --zero=zero:5080 --security "whitelist=${WHITELISTED}"
 ```
 The "WHITELISTED" environment variable can be intiialized as described [in this post](https://discuss.dgraph.io/t/suggestion-for-how-to-add-docker-compose-network-to-whitelist/9600). We need to whitelist these IPs because the docker container runs with it's own IP address.
 

--- a/examples/simple/requirements.txt
+++ b/examples/simple/requirements.txt
@@ -1,1 +1,4 @@
-pydgraph>=2.0.2
+grpcio==1.38.1
+protobuf==3.17.3
+pydgraph==21.3.0
+six==1.16.0

--- a/examples/simple/simple.py
+++ b/examples/simple/simple.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import datetime
 import json
 

--- a/examples/tls/.gitignore
+++ b/examples/tls/.gitignore
@@ -1,1 +1,2 @@
 tls/*
+!tls/.gitkeep

--- a/examples/tls/README.md
+++ b/examples/tls/README.md
@@ -25,18 +25,19 @@ information.
 Create the root CA. All certificates and keys are created in the `tls` directory.
 
 ```sh
-dgraph cert
+docker run -t --volume $PWD/tls:/dgraph-tls dgraph/dgraph:latest dgraph cert --dir /dgraph-tls
 ```
+
 
 Now create the Alpha server certificate (node.crt) and key (node.key) and client
 certificate (client.user.crt) key (client.user.key).
 
 ```sh
-dgraph cert -n localhost
+docker run -t --volume $PWD/tls:/dgraph-tls dgraph/dgraph:latest dgraph cert --nodes localhost --dir /dgraph-tls
 ```
 
 ```sh
-dgraph cert -c user
+docker run -t --volume $PWD/tls:/dgraph-tls dgraph/dgraph:latest dgraph cert --client user --dir /dgraph-tls
 ```
 
 The following files should now be in the `tls` directory:

--- a/examples/tls/docker-compose.yml
+++ b/examples/tls/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     labels:
       cluster: test
       service: zero
-    command: dgraph zero -o 0 --my=zero1:5080 --replicas 3 --idx 1 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: dgraph zero --port_offset 0 --my=zero1:5080 --replicas 3 --raft idx=1 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   zero2:
     image: dgraph/dgraph:latest
@@ -24,7 +24,7 @@ services:
     labels:
       cluster: test
       service: zero
-    command: dgraph zero -o 2 --my=zero2:5082 --replicas 3 --idx 2 --logtostderr -v=2 --peer=zero1:5080
+    command: dgraph zero --port_offset 2 --my=zero2:5082 --replicas 3 --raft idx=2 --logtostderr -v=2 --peer=zero1:5080
 
   zero3:
     image: dgraph/dgraph:latest
@@ -38,7 +38,7 @@ services:
     labels:
       cluster: test
       service: zero
-    command: dgraph zero -o 3 --my=zero3:5083 --replicas 3 --idx 3 --logtostderr -v=2 --peer=zero1:5080
+    command: dgraph zero --port_offset 3 --my=zero3:5083 --replicas 3 --raft idx=3 --logtostderr -v=2 --peer=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:latest
@@ -59,7 +59,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: dgraph alpha -o 0 --my=alpha1:7080 --lru_mb=1024 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16  --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s --tls_dir /dgraph-tls --tls_client_auth=REQUIREANDVERIFY
+    command: dgraph alpha --port_offset 0 --my=alpha1:7080  --zero=zero1:5080 --expose_trace --trace ratio=1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --security whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16  --acl secret-file=/dgraph-acl/hmac-secret;access-ttl=3s;refresh-ttl=5s --tls client-auth-type=REQUIREANDVERIFY;ca-cert=/dgraph-tls/ca.crt;server-cert=/dgraph-tls/node.crt;server-key=/dgraph-tls/node.key
 
   alpha2:
     image: dgraph/dgraph:latest
@@ -82,7 +82,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: dgraph alpha -o 2 --my=alpha2:7082 --lru_mb=1024 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s --tls_dir /dgraph-tls --tls_client_auth=REQUIREANDVERIFY
+    command: dgraph alpha --port_offset 2 --my=alpha2:7082  --zero=zero1:5080 --expose_trace --trace ratio=1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --security whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl secret-file=/dgraph-acl/hmac-secret;access-ttl=3s;refresh-ttl=5s --tls client-auth-type=REQUIREANDVERIFY;ca-cert=/dgraph-tls/ca.crt;server-cert=/dgraph-tls/node.crt;server-key=/dgraph-tls/node.key
 
   alpha3:
     image: dgraph/dgraph:latest
@@ -105,4 +105,4 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: dgraph alpha -o 3 --my=alpha3:7083 --lru_mb=1024 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s --tls_dir /dgraph-tls --tls_client_auth=REQUIREANDVERIFY
+    command: dgraph alpha --port_offset 3 --my=alpha3:7083  --zero=zero1:5080 --expose_trace --trace ratio=1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --security whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl secret-file=/dgraph-acl/hmac-secret;access-ttl=3s;refresh-ttl=5s --tls client-auth-type=REQUIREANDVERIFY;ca-cert=/dgraph-tls/ca.crt;server-cert=/dgraph-tls/node.crt;server-key=/dgraph-tls/node.key

--- a/examples/tls/requirements.txt
+++ b/examples/tls/requirements.txt
@@ -1,3 +1,4 @@
-grpcio==1.23.0
-pydgraph==2.0.2
-grpc==0.3-19
+grpcio==1.38.1
+protobuf==3.17.3
+pydgraph==21.3.0
+six==1.16.0

--- a/examples/tls/tls_example.py
+++ b/examples/tls/tls_example.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python3
-
+#!/usr/bin/env python3
 import pydgraph
 import grpc
 

--- a/pydgraph/client_stub.py
+++ b/pydgraph/client_stub.py
@@ -92,14 +92,14 @@ class DgraphClientStub(object):
     @staticmethod
     def from_slash_endpoint(cloud_end_point, api_key):
         return from_cloud(cloud_end_point, api_key)
-    
+
     # Usage:
     # import pydgraph
     # client_stub = pydgraph.DgraphClientStub.from_cloud("cloud_endpoint", "api-key")
     # client = pydgraph.DgraphClient(client_stub)
     @staticmethod
     def from_cloud(cloud_end_point, api_key):
-    """Returns Dgraph Client stub for the Slash GraphQL endpoint"""
+        """Returns Dgraph Client stub for the Slash GraphQL endpoint"""
         url = urlparse(slash_end_point)
         url_parts = url.netloc.split(".", 1)
         host = url_parts[0] + ".grpc." + url_parts[1]


### PR DESCRIPTION
This updates examples to support Dgraph v21.03:

* updated requirements for pydgraph==21.3.0
* examples/simple/README.md - fixed embedded docker-compose for superflags
* examples/tls/docker-compose.yml - updated for superflags
* examples/tls/README.md - updated instructions for cert creation to work on all platforms (win/mac/lin)
   * dgraph no longer released on mac/win, but as docker is common requirement, updated instructions work
* tested changes on mac os w/ docker-desktop using dgraph v21.03.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/pydgraph/171)
<!-- Reviewable:end -->
