### PR TITLE
accept grpc endpoint or /graphql endpoint in from_cloud function

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ There are many ways to set up your local Python environment. We suggest some san
 To build and install pydgraph locally, run
 
 ```sh
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 If you have made changes to the `pydgraph/proto/api.proto` file, you need need

--- a/pydgraph/client_stub.py
+++ b/pydgraph/client_stub.py
@@ -87,22 +87,21 @@ class DgraphClientStub(object):
         del self.channel
         del self.stub
 
-    # from_slash_endpoint is deprecated and will be removed in v21.07 release.
-    # Use from_cloud method to connect to dgraph cloud backend.
-    @staticmethod
-    def from_slash_endpoint(cloud_endpoint, api_key):
-        return from_cloud(cloud_endpoint, api_key)
-
+    # accepts grpc endpoint as copied in cloud console as well as graphql endpoint
     # Usage:
     # import pydgraph
     # client_stub = pydgraph.DgraphClientStub.from_cloud("cloud_endpoint", "api-key")
     # client = pydgraph.DgraphClient(client_stub)
     @staticmethod
     def from_cloud(cloud_endpoint, api_key):
-        """Returns Dgraph Client stub for the Slash GraphQL endpoint"""
-        url = urlparse(cloud_endpoint)
-        url_parts = url.netloc.split(".", 1)
-        host = url_parts[0] + ".grpc." + url_parts[1]
+        """Returns Dgraph Client stub for the Dgraph Cloud endpoint"""
+        if cloud_endpoint.startswith("http"): # catch http:// and https://
+            host = urlparse(cloud_endpoint).netloc
+        else:
+            host = cloud_endpoint.split(":",1)[0] # remove port if any
+        if not ".grpc." in host:
+            url_parts = host.split(".", 1)
+            host = url_parts[0] + ".grpc." + url_parts[1]
         creds = grpc.ssl_channel_credentials()
         call_credentials = grpc.metadata_call_credentials(
             lambda context, callback: callback((("authorization", api_key),), None))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,9 +18,7 @@ __author__ = 'Garvit Pahal <garvit@dgraph.io>'
 __maintainer__ = 'Martin Martinez Rivera <martinmr@dgraph.io>'
 
 import unittest
-
 import pydgraph
-
 
 class TestDgraphClient(unittest.TestCase):
     """Tests construction of Dgraph client."""
@@ -28,13 +26,11 @@ class TestDgraphClient(unittest.TestCase):
         with self.assertRaises(ValueError):
             pydgraph.DgraphClient()
 
-
 def suite():
     """Returns a tests suite object."""
     suite_obj = unittest.TestSuite()
     suite_obj.addTest(TestDgraphClient())
     return suite_obj
-
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()

--- a/tests/test_client_stub.py
+++ b/tests/test_client_stub.py
@@ -52,13 +52,33 @@ class TestDgraphClientStub(helper.ClientIntegrationTestCase):
         with self.assertRaises(Exception):
             client_stub.check_version(pydgraph.Check())
 
+class TestFromCloud(unittest.TestCase):
+    """Tests the from_cloud function"""
+    def test_from_cloud(self):
+        testcases = [
+            {"endpoint": "godly.grpc.region.aws.cloud.dgraph.io"},
+            {"endpoint": "godly.grpc.region.aws.cloud.dgraph.io:443"},
+            {"endpoint": "https://godly.region.aws.cloud.dgraph.io/graphql"},
+            {"endpoint": "godly.region.aws.cloud.dgraph.io"},
+            {"endpoint": "https://godly.region.aws.cloud.dgraph.io"},
+            {"endpoint": "godly.region.aws.cloud.dgraph.io:random"},
+            {"endpoint": "random:url", "error": True},
+            {"endpoint": "google", "error": True},
+        ]
+
+        for case in testcases:
+            try:
+                pydgraph.DgraphClientStub.from_cloud(case["endpoint"], "api-key")
+            except IndexError as e:
+                if not case["error"]:
+                    # we didn't expect an error
+                    raise(e)
 
 def suite():
     """Returns a test suite object."""
     suite_obj = unittest.TestSuite()
     suite_obj.addTest(TestDgraphClientStub())
     return suite_obj
-
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()


### PR DESCRIPTION
This PR also deprecates from_slash_endpoint function. Fixes #189