### PR TITLE
chore(ci): fix test script + use latest docker image

### DIFF
--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -43,7 +43,6 @@ alphaGrpcPort=$(DockerCompose port alpha1 9080 | awk -F: '{print $2}')
 popd
 export TEST_SERVER_ADDR="localhost:$alphaGrpcPort"
 echo "Using TEST_SERVER_ADDR=$TEST_SERVER_ADDR"
-#coverage run --source=pydgraph --omit=pydgraph/proto/* setup.py test
 pytest
 tests_failed="$?"
 stopCluster

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -35,14 +35,6 @@ function stopCluster() {
 
 readonly SRCDIR=$(readlink -f ${BASH_SOURCE[0]%/*})
 
-# Install dependencies
-pip install -r requirements_dev.txt
-pip_failed="$?"
-if [ "$tests_failed" -ne 0 ]; then
-    exit 1
-fi
-# pip install coveralls (will figure out later)
-
 # Run cluster and tests
 pushd $(dirname $SRCDIR)
 pushd $SRCDIR/../tests

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:master
+    image: dgraph/dgraph:latest
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
         limits:
           memory: 32G
   alpha2:
-    image: dgraph/dgraph:master
+    image: dgraph/dgraph:latest
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -43,7 +43,7 @@ services:
         limits:
           memory: 32G
   alpha3:
-    image: dgraph/dgraph:master
+    image: dgraph/dgraph:latest
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -63,7 +63,7 @@ services:
         limits:
           memory: 32G
   zero1:
-    image: dgraph/dgraph:master
+    image: dgraph/dgraph:latest
     working_dir: /data/zero1
     labels:
       cluster: test
@@ -77,7 +77,7 @@ services:
         limits:
           memory: 32G
   zero2:
-    image: dgraph/dgraph:master
+    image: dgraph/dgraph:latest
     working_dir: /data/zero2
     depends_on:
     - zero1
@@ -93,7 +93,7 @@ services:
         limits:
           memory: 32G
   zero3:
-    image: dgraph/dgraph:master
+    image: dgraph/dgraph:latest
     working_dir: /data/zero3
     depends_on:
     - zero2


### PR DESCRIPTION
Test script was referencing requirements_dev.  We now require dev dependencies be installed before running script.  Also, we use the latest docker image now.