### PR TITLE
chore(ci): test against latest dgraph on main

### DIFF
--- a/.github/workflows/ci-pydgraph-tests.yml
+++ b/.github/workflows/ci-pydgraph-tests.yml
@@ -24,11 +24,12 @@ jobs:
           path: dgraph
           repository: dgraph-io/dgraph
           ref: main
-      - name: Checkout Dgo repo
+      - name: Checkout pydgraph repo
         uses: actions/checkout@v3
         with:
           path: pydgraph
           repository: dgraph-io/pydgraph
+          ref: ${{ github.ref }}
       - name: Get Go Version
         run: |
           #!/bin/bash
@@ -59,4 +60,4 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[dev]
       - name: Run tests
-        run: cd pydgraph && bash scripts/local-test.sh
+        run: cd pydgraph && DGRAPH_IMAGE_TAG=local bash scripts/local-test.sh

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
         limits:
           memory: 32G
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -43,7 +43,7 @@ services:
         limits:
           memory: 32G
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -63,7 +63,7 @@ services:
         limits:
           memory: 32G
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
     working_dir: /data/zero1
     labels:
       cluster: test
@@ -77,7 +77,7 @@ services:
         limits:
           memory: 32G
   zero2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
     working_dir: /data/zero2
     depends_on:
     - zero1
@@ -93,7 +93,7 @@ services:
         limits:
           memory: 32G
   zero3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
     working_dir: /data/zero3
     depends_on:
     - zero2


### PR DESCRIPTION
CI was running against latest image.  This will not catch bugs until we push a dgraph release.  For CI we build dgraph image locally and run pydgraph CI against this image.  Also, we were not checking out the version of pydgraph on PR's.  We fix this issue.