### PR TITLE
Add Jupyter Notebook example

### DIFF
--- a/examples/notebook/self_managed_cluster.ipynb
+++ b/examples/notebook/self_managed_cluster.ipynb
@@ -18,7 +18,17 @@
     "\n",
     "This example notebook uses a schema and data from the [Dgraph ICIJ offshore leaks repository](https://github.com/dgraph-io/vlg). Please refer to that repo for a discussion of the schema and data.\n",
     "\n",
-    "**Please note that this notebook updates the schema in the configured cluster and loads data into it.**"
+    "Covered in this example:\n",
+    "* load a GraphQL schema\n",
+    "* use the Dgraph Live Loader to load data\n",
+    "* create a DQL-based pydgraph client\n",
+    "* perform DQL queries and mutations\n",
+    "* create a GraphQL client\n",
+    "* perform a GraphQL query\n",
+    "* perform a recursive query using DQL\n",
+    "* visualize query results using Graphistry\n",
+    "\n",
+    "**Please note that this notebook updates the schema and loads data into the configured cluster.**"
    ]
   },
   {
@@ -58,18 +68,18 @@
     "    except socket.error:\n",
     "        return False\n",
     "\n",
-    "# check ports to ensure access. these are the defaults, change these to match your custom \n",
+    "# check ports to ensure access. these are the defaults, change these to match your custom setup if different\n",
     "dgraph_http_port = 8080\n",
     "dgraph_grpc_port = 9080\n",
     "dgraph_zero_port = 5080\n",
     "if not check_port(dgraph_hostname, dgraph_http_port):\n",
-    "    print(f\"Port {dgraph_http_port} at {dgraph_hostname} not responding, is the server running?\")\n",
-    "elif not check_port(dgraph_hostname, dgraph_grpc_port):\n",
-    "    print(f\"Port {dgraph_grpc_port} at {dgraph_hostname} not responding, is the server running?\")\n",
-    "elif not check_port(dgraph_hostname, dgraph_zero_port):\n",
-    "    print(f\"Port {dgraph_zero_port} at {dgraph_hostname} not responding, is the server running?\")\n",
-    "else:\n",
-    "    print(\"Required ports accepting connections\")"
+    "    raise Exception(f\"Port {dgraph_http_port} at {dgraph_hostname} not responding, is the server running?\")\n",
+    "if not check_port(dgraph_hostname, dgraph_grpc_port):\n",
+    "    raise Exception(f\"Port {dgraph_grpc_port} at {dgraph_hostname} not responding, is the server running?\")\n",
+    "if not check_port(dgraph_hostname, dgraph_zero_port):\n",
+    "    raise Exception(f\"Port {dgraph_zero_port} at {dgraph_hostname} not responding, is the server running?\")\n",
+    "\n",
+    "print(\"Required ports accepting connections\")"
    ]
   },
   {
@@ -80,7 +90,9 @@
    "source": [
     "# Apply a GraphQL Schema to the cluster\n",
     "\n",
+    "# download the schema\n",
     "!curl -Ss https://raw.githubusercontent.com/dgraph-io/vlg/main/schema/schema.graphql --output schema.graphql\n",
+    "# update the schema in the cluster\n",
     "admin_endpoint = f\"http://{dgraph_hostname}:{dgraph_http_port}/admin/schema\"\n",
     "!curl --data-binary '@./schema.graphql' {admin_endpoint}"
    ]
@@ -93,9 +105,10 @@
    "source": [
     "# Load data into the cluster\n",
     "\n",
+    "# download the rdf files\n",
     "!curl -Ss https://raw.githubusercontent.com/dgraph-io/vlg/main/rdf-subset/data.rdf.gz --output data.rdf.gz\n",
     "\n",
-    "# Find ways to load data into the cluster\n",
+    "# find ways to load data into the cluster\n",
     "import shutil, os, platform\n",
     "\n",
     "pwd = os.getcwd()\n",
@@ -123,7 +136,7 @@
    "source": [
     "# Install pydgraph\n",
     "\n",
-    "!pip install pydgraph"
+    "%pip install pydgraph"
    ]
   },
   {
@@ -132,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Initialize a pydgraph client\n",
+    "# Create a pydgraph client\n",
     "\n",
     "import pydgraph\n",
     "\n",
@@ -147,21 +160,246 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Perform a DQL query\n",
+    "# Perform a DQL query (stem search on the name predicate)\n",
     "\n",
     "import json\n",
     "\n",
     "query = \"\"\"\n",
-    "{\n",
-    "  q(func: anyoftext(Record.name, \"living\"), first: 10) {\n",
+    "query fulltext($name: string) {\n",
+    "  q(func: anyoftext(Record.name, $name), first: 10) {\n",
+    "    uid\n",
     "    id: Record.nodeID\n",
     "    name: Record.name\n",
     "  }\n",
     "}\n",
     "\"\"\"\n",
-    "res = pyd_client.txn(read_only=True).query(query)\n",
-    "print(json.dumps(json.loads(res.json), indent=2))\n"
+    "res = pyd_client.txn(read_only=True).query(query=query, variables={\"$name\": \"living\"})\n",
+    "records = json.loads(res.json)\n",
+    "print(json.dumps(records, indent=2))\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform a DQL mutation\n",
+    "\n",
+    "txn = pyd_client.txn()\n",
+    "try:\n",
+    "    uid = records['q'][0]['uid']\n",
+    "    name = f\"New Name (formerly {records['q'][0]['name']})\"\n",
+    "    p = {\n",
+    "        'uid': uid,\n",
+    "        'Record.name': name\n",
+    "    }\n",
+    "    response = txn.mutate(set_obj=p)\n",
+    "    txn.commit()\n",
+    "finally:\n",
+    "    txn.discard()\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install an open-source GraphQL client\n",
+    "\n",
+    "%pip install python-graphql-client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a GraphQL client\n",
+    "\n",
+    "from python_graphql_client import GraphqlClient\n",
+    "\n",
+    "gql_client = GraphqlClient(endpoint=f\"http://{dgraph_hostname}:{dgraph_http_port}/graphql\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform a GraphQL query (stem search on the name predicate)\n",
+    "\n",
+    "ft_query = \"\"\"\n",
+    "query ($filter: EntityFilter, $first: Int) {\n",
+    "  queryEntity(filter: $filter, first: $first) {\n",
+    "    id: nodeID\n",
+    "    type: __typename\n",
+    "    name\n",
+    "  }\n",
+    "}\n",
+    "\"\"\"\n",
+    "variables = {\n",
+    "    \"filter\": {\n",
+    "        \"name\": {\n",
+    "            \"anyoftext\": \"living\"\n",
+    "        }\n",
+    "    },\n",
+    "    \"first\": 10\n",
+    "}\n",
+    "data = gql_client.execute(query=ft_query, variables=variables)\n",
+    "for res in data['data']['queryEntity']:\n",
+    "    print(res['name'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform a recursive DQL query on a list of known records\n",
+    "\n",
+    "highly_connected_records = ['236724', '230000018', '54662', '23000136', '240000001', '23000147', '81027146', '23000156', '23000330', '81027090', '23000133', '32000236', '11001746', '81029389', '23000213', '298333', '288469', '23000046', '23000280', '11011863', '12160432', '96909', '11008027', '298293', '23000381', '11001708', '285729', '11012037', '23000198', '23000219', '294268', '230000057', '49684', '23000362', '23000228', '11007372', '230000005', '80000191', '11009351', '23000400', '23000235', '23000406', '23000162', '23000365', '80011301', '23000281', '80011987', '58007938', '88002083', '11011539', '264051', '298258', '240230001', '297687', '230000038', '24000074', '20642', '230000007', '11010643', '23000222', '58922', '81027087', '279944', '23000377', '240360001', '298170', '24883', '11012290', '11009218', '23000130', '43724', '225000056', '11009139', '298147', '237148', '23000396', '230000054', '237076', '237583', '23000146', '11006103', '230000021', '11012118', '120001922', '230000066', '236748', '23000131', '295141', '298166', '230000025', '230000020', '11000489', '23000204', '23000260', '11012146', '56917', '11011469', '271169', '236832', '81001128', '33000151', '81073055', '11010502', '75595', '32000238', '240110001', '23000256', '23000001', '32000226', '23000237', '11014056', '56072048', '50622', '23000437', '23000307', '32000235', '24000031', '14025646', '263908', '11010460', '23000145', '230000070', '260937', '23000360', '23000166', '271677', '58009618', '297689', '263996', '14026068', '230000004', '230000016', '23000161', '23000157', '298020', '297596', '11003948', '230000017', '58044817', '23000141', '230000003', '290240', '58034506', '81038065', '88007148', '82019954', '23000343', '56072081', '80051573', '80086304']\n",
+    "\n",
+    "recurse_query = \"\"\"\n",
+    "{\n",
+    "    q(func: eq(Record.nodeID, {LIST})) @recurse(depth: 8) {\n",
+    "        # predicates to return for each recurse\n",
+    "        id: Record.nodeID\n",
+    "        name: Record.name\n",
+    "        type: <dgraph.type>\n",
+    "        # predicates to loop through\n",
+    "        hasaddress: Record.hasAddress\n",
+    "        addressFor: RecordRecord.addressFor\n",
+    "        hasOfficer: Record.hasOfficer\n",
+    "        officerFor: Record.officerFor\n",
+    "        hasIntermediary: Record.hasIntermediary\n",
+    "        intermediaryFor: Record.intermediaryFor\n",
+    "        connectedTo: RecordRecord.connectedTo  \n",
+    "  }\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "recurse_query = recurse_query.replace(\"{LIST}\", json.dumps(highly_connected_records))\n",
+    "res = pyd_client.txn(read_only=True).query(recurse_query)\n",
+    "data = json.loads(res.json)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert the nested JSON DQL result to a dictionary of nodes and an array of edges.\n",
+    "# These structures are common requirements for graph analysis and visualization\n",
+    "\n",
+    "from pydgraph import convert\n",
+    "\n",
+    "nodes = {}\n",
+    "edges = []\n",
+    "convert.extract_dict(nodes, edges, data)\n",
+    "print(\"nodes count\", len(nodes), \", edges count\", len(edges))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install pandas\n",
+    "\n",
+    "%pip install pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Transform the node dictionary to Pandas dataframe\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "nodes_df = pd.DataFrame.from_dict(nodes, orient='index')\n",
+    "nodes_df.sample(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Transform the edges array to Pandas dataframe\n",
+    "\n",
+    "edges_df = pd.DataFrame(edges)\n",
+    "edges_df.sample(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup Graphistry\n",
+    "\n",
+    "# sign up for a free Graphisty account at https://hub.graphistry.com. Use the \"Create Account\" flow in which you\n",
+    "# specify a username and password (not the OAUTH flow).\n",
+    "\n",
+    "%pip install graphistry\n",
+    "\n",
+    "import graphistry\n",
+    "print(\"Graphistry version\", graphistry.__version__)\n",
+    "\n",
+    "graphistry_username = \"matthew95\"\n",
+    "graphistry_password = \"2a3b5c7d11e\"\n",
+    "graphistry.register(api=3, protocol=\"https\", server=\"hub.graphistry.com\", username=graphistry_username, password=graphistry_password)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize the recursively-derived subgraph in Graphistry\n",
+    "\n",
+    "g = graphistry.nodes(nodes_df, 'id').edges(edges_df, 'src', 'dst').bind(point_title='name')\n",
+    "# set colors by node type\n",
+    "g2 = g.encode_point_color('type', categorical_mapping={\n",
+    "    'Entity': '#3bdbdb', \n",
+    "    'Intermediary': '#E99233', \n",
+    "    'Officer': '#6DB364', \n",
+    "    'Address': '#F7D82F'\n",
+    "}, default_mapping='gray')\n",
+    "# set icons by node type\n",
+    "g3 = g2.encode_point_icon('type', shape=\"circle\", #clip excess\n",
+    "  categorical_mapping={\n",
+    "      'Entity': 'fa-building',\n",
+    "      'Intermediary': 'fa-handshake-o',\n",
+    "      'Address': 'fa-map-marker',\n",
+    "      'Officer': 'fa-user'\n",
+    "  },\n",
+    "  default_mapping=\"question\")\n",
+    "\n",
+    "# render the visualization\n",
+    "g3.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/notebook/self_managed_cluster.ipynb
+++ b/examples/notebook/self_managed_cluster.ipynb
@@ -14,7 +14,7 @@
     "docker run --rm -it -p 8080:8080 -p 9080:9080 -p 5080:5080 dgraph/standalone:latest\n",
     "```\n",
     "\n",
-    "For more information on starting Dgraph with Docker or Docker Compose, see this [document](https://dgraph.io/docs/learn/data-engineer/get-started-with-dgraph/tutorial-1/).\n",
+    "For more information on starting Dgraph with Docker or Docker Compose, see this [document](https://dgraph.io/docs/learn/data-engineer/get-started-with-dgraph/tutorial-1/). This notebook was tested both via a local Jupyter environment and on Google Colab.\n",
     "\n",
     "This example notebook uses a schema and data from the [Dgraph ICIJ offshore leaks repository](https://github.com/dgraph-io/vlg). Please refer to that repo for a discussion of the schema and data.\n",
     "\n",
@@ -260,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Perform a recursive DQL query on a list of known records (records are highly-connected)\n",
+    "# Perform a recursive DQL query on a list of known records (these records are highly-connected)\n",
     "\n",
     "highly_connected_records = ['236724', '230000018', '54662', '23000136', '240000001', '23000147', '81027146', '23000156', '23000330', '81027090', '23000133', '32000236', '11001746', '81029389', '23000213', '298333', '288469', '23000046', '23000280', '11011863', '12160432', '96909', '11008027', '298293', '23000381', '11001708', '285729', '11012037', '23000198', '23000219', '294268', '230000057', '49684', '23000362', '23000228', '11007372', '230000005', '80000191', '11009351', '23000400', '23000235', '23000406', '23000162', '23000365', '80011301', '23000281', '80011987', '58007938', '88002083', '11011539', '264051', '298258', '240230001', '297687', '230000038', '24000074', '20642', '230000007', '11010643', '23000222', '58922', '81027087', '279944', '23000377', '240360001', '298170', '24883', '11012290', '11009218', '23000130', '43724', '225000056', '11009139', '298147', '237148', '23000396', '230000054', '237076', '237583', '23000146', '11006103', '230000021', '11012118', '120001922', '230000066', '236748', '23000131', '295141', '298166', '230000025', '230000020', '11000489', '23000204', '23000260', '11012146', '56917', '11011469', '271169', '236832', '81001128', '33000151', '81073055', '11010502', '75595', '32000238', '240110001', '23000256', '23000001', '32000226', '23000237', '11014056', '56072048', '50622', '23000437', '23000307', '32000235', '24000031', '14025646', '263908', '11010460', '23000145', '230000070', '260937', '23000360', '23000166', '271677', '58009618', '297689', '263996', '14026068', '230000004', '230000016', '23000161', '23000157', '298020', '297596', '11003948', '230000017', '58044817', '23000141', '230000003', '290240', '58034506', '81038065', '88007148', '82019954', '23000343', '56072081', '80051573', '80086304']\n",
     "\n",
@@ -359,8 +359,9 @@
     "import graphistry\n",
     "print(\"Graphistry version\", graphistry.__version__)\n",
     "\n",
-    "graphistry_username = \"matthew95\"\n",
-    "graphistry_password = \"2a3b5c7d11e\"\n",
+    "# replace these <place holders> with your credentials\n",
+    "graphistry_username = \"<YOUR GRAPHISTRY USERNAME>\"\n",
+    "graphistry_password = \"<YOUR GRAPHISTRY PASSWORD>\"\n",
     "graphistry.register(api=3, protocol=\"https\", server=\"hub.graphistry.com\", username=graphistry_username, password=graphistry_password)\n"
    ]
   },
@@ -393,13 +394,6 @@
     "# render the visualization\n",
     "g3.plot()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -418,7 +412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/examples/notebook/self_managed_cluster.ipynb
+++ b/examples/notebook/self_managed_cluster.ipynb
@@ -105,26 +105,25 @@
    "source": [
     "# Load data into the cluster\n",
     "\n",
-    "# download the rdf files\n",
+    "# download the rdf file\n",
     "!curl -Ss https://raw.githubusercontent.com/dgraph-io/vlg/main/rdf-subset/data.rdf.gz --output data.rdf.gz\n",
     "\n",
     "# find ways to load data into the cluster\n",
     "import shutil, os, platform\n",
     "\n",
     "pwd = os.getcwd()\n",
-    "if shutil.which('docker') is not None:\n",
+    "if shutil.which('docker'):\n",
     "    docker_host = dgraph_hostname\n",
     "    if dgraph_hostname == 'localhost':\n",
     "        docker_host = 'host.docker.internal'\n",
     "    !docker run -it -v {pwd}:/data dgraph/standalone:latest dgraph live -f /data/data.rdf.gz --alpha {docker_host}:{dgraph_grpc_port} --zero {docker_host}:{dgraph_zero_port}\n",
-    "elif shutil.which('dgraph') is not None:\n",
+    "elif shutil.which('dgraph'):\n",
     "    !dgraph live -f ./data.rdf.gz --alpha {dgraph_hostname}:{dgraph_grpc_port} --zero {dgraph_hostname}:{dgraph_zero_port}\n",
-    "elif platform.system == \"Linux\":\n",
+    "elif platform.system() == \"Linux\":\n",
     "    !curl https://get.dgraph.io -sSf | bash -s -- -y\n",
     "    !dgraph live -f ./data.rdf.gz --alpha {dgraph_hostname}:{dgraph_grpc_port} --zero {dgraph_hostname}:{dgraph_zero_port}\n",
     "else:\n",
     "    raise Exception(\"Unable to find a way to load data into your cluster.\")\n",
-    "\n",
     "    "
    ]
   },
@@ -207,7 +206,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install an open-source GraphQL client\n",
+    "# Install an open source GraphQL client\n",
     "\n",
     "%pip install python-graphql-client"
    ]
@@ -261,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Perform a recursive DQL query on a list of known records\n",
+    "# Perform a recursive DQL query on a list of known records (records are highly-connected)\n",
     "\n",
     "highly_connected_records = ['236724', '230000018', '54662', '23000136', '240000001', '23000147', '81027146', '23000156', '23000330', '81027090', '23000133', '32000236', '11001746', '81029389', '23000213', '298333', '288469', '23000046', '23000280', '11011863', '12160432', '96909', '11008027', '298293', '23000381', '11001708', '285729', '11012037', '23000198', '23000219', '294268', '230000057', '49684', '23000362', '23000228', '11007372', '230000005', '80000191', '11009351', '23000400', '23000235', '23000406', '23000162', '23000365', '80011301', '23000281', '80011987', '58007938', '88002083', '11011539', '264051', '298258', '240230001', '297687', '230000038', '24000074', '20642', '230000007', '11010643', '23000222', '58922', '81027087', '279944', '23000377', '240360001', '298170', '24883', '11012290', '11009218', '23000130', '43724', '225000056', '11009139', '298147', '237148', '23000396', '230000054', '237076', '237583', '23000146', '11006103', '230000021', '11012118', '120001922', '230000066', '236748', '23000131', '295141', '298166', '230000025', '230000020', '11000489', '23000204', '23000260', '11012146', '56917', '11011469', '271169', '236832', '81001128', '33000151', '81073055', '11010502', '75595', '32000238', '240110001', '23000256', '23000001', '32000226', '23000237', '11014056', '56072048', '50622', '23000437', '23000307', '32000235', '24000031', '14025646', '263908', '11010460', '23000145', '230000070', '260937', '23000360', '23000166', '271677', '58009618', '297689', '263996', '14026068', '230000004', '230000016', '23000161', '23000157', '298020', '297596', '11003948', '230000017', '58044817', '23000141', '230000003', '290240', '58034506', '81038065', '88007148', '82019954', '23000343', '56072081', '80051573', '80086304']\n",
     "\n",
@@ -295,7 +294,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Convert the nested JSON DQL result to a dictionary of nodes and an array of edges.\n",
+    "# Convert the nested JSON DQL result to a dictionary of nodes and an array of edges using a utility \n",
+    "# function in pydgraph (convert.extract_dict).\n",
     "# These structures are common requirements for graph analysis and visualization\n",
     "\n",
     "from pydgraph import convert\n",
@@ -380,7 +380,7 @@
     "    'Officer': '#6DB364', \n",
     "    'Address': '#F7D82F'\n",
     "}, default_mapping='gray')\n",
-    "# set icons by node type\n",
+    "# set font awesome icons by node type\n",
     "g3 = g2.encode_point_icon('type', shape=\"circle\", #clip excess\n",
     "  categorical_mapping={\n",
     "      'Entity': 'fa-building',\n",

--- a/examples/notebook/self_managed_cluster.ipynb
+++ b/examples/notebook/self_managed_cluster.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# pydgraph example notebook\n",
+    "\n",
+    "## Self-managed cluster version\n",
+    "\n",
+    "This example notebook version uses an an existing Dgraph cluster that you control. If you have Docker, the TLDR; version is:\n",
+    "\n",
+    "```sh\n",
+    "docker run --rm -it -p 8080:8080 -p 9080:9080 -p 5080:5080 dgraph/standalone:latest\n",
+    "```\n",
+    "\n",
+    "For more information on starting Dgraph with Docker or Docker Compose, see this [document](https://dgraph.io/docs/learn/data-engineer/get-started-with-dgraph/tutorial-1/).\n",
+    "\n",
+    "This example notebook uses a schema and data from the [Dgraph ICIJ offshore leaks repository](https://github.com/dgraph-io/vlg). Please refer to that repo for a discussion of the schema and data.\n",
+    "\n",
+    "**Please note that this notebook updates the schema in the configured cluster and loads data into it.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the hostname of the Dgraph alpha service\n",
+    "dgraph_hostname = \"localhost\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This cell checks that the required ports for the Dgraph cluster are accessible from this notebook. It also sets\n",
+    "# important port variables used in later cells\n",
+    "\n",
+    "import socket\n",
+    "\n",
+    "def check_port(url, port):\n",
+    "    \"\"\"\n",
+    "    check_port returns true if the port at the url is accepting connections\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n",
+    "        sock.settimeout(3)  # Set a timeout value for the connection attempt\n",
+    "        result = sock.connect_ex((url, port))\n",
+    "        sock.close()\n",
+    "        if result == 0:\n",
+    "            return True\n",
+    "        else:\n",
+    "            return False\n",
+    "    except socket.error:\n",
+    "        return False\n",
+    "\n",
+    "# check ports to ensure access. these are the defaults, change these to match your custom \n",
+    "dgraph_http_port = 8080\n",
+    "dgraph_grpc_port = 9080\n",
+    "dgraph_zero_port = 5080\n",
+    "if not check_port(dgraph_hostname, dgraph_http_port):\n",
+    "    print(f\"Port {dgraph_http_port} at {dgraph_hostname} not responding, is the server running?\")\n",
+    "elif not check_port(dgraph_hostname, dgraph_grpc_port):\n",
+    "    print(f\"Port {dgraph_grpc_port} at {dgraph_hostname} not responding, is the server running?\")\n",
+    "elif not check_port(dgraph_hostname, dgraph_zero_port):\n",
+    "    print(f\"Port {dgraph_zero_port} at {dgraph_hostname} not responding, is the server running?\")\n",
+    "else:\n",
+    "    print(\"Required ports accepting connections\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply a GraphQL Schema to the cluster\n",
+    "\n",
+    "!curl -Ss https://raw.githubusercontent.com/dgraph-io/vlg/main/schema/schema.graphql --output schema.graphql\n",
+    "admin_endpoint = f\"http://{dgraph_hostname}:{dgraph_http_port}/admin/schema\"\n",
+    "!curl --data-binary '@./schema.graphql' {admin_endpoint}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data into the cluster\n",
+    "\n",
+    "!curl -Ss https://raw.githubusercontent.com/dgraph-io/vlg/main/rdf-subset/data.rdf.gz --output data.rdf.gz\n",
+    "\n",
+    "# Find ways to load data into the cluster\n",
+    "import shutil, os, platform\n",
+    "\n",
+    "pwd = os.getcwd()\n",
+    "if shutil.which('docker') is not None:\n",
+    "    docker_host = dgraph_hostname\n",
+    "    if dgraph_hostname == 'localhost':\n",
+    "        docker_host = 'host.docker.internal'\n",
+    "    !docker run -it -v {pwd}:/data dgraph/standalone:latest dgraph live -f /data/data.rdf.gz --alpha {docker_host}:{dgraph_grpc_port} --zero {docker_host}:{dgraph_zero_port}\n",
+    "elif shutil.which('dgraph') is not None:\n",
+    "    !dgraph live -f ./data.rdf.gz --alpha {dgraph_hostname}:{dgraph_grpc_port} --zero {dgraph_hostname}:{dgraph_zero_port}\n",
+    "elif platform.system == \"Linux\":\n",
+    "    !curl https://get.dgraph.io -sSf | bash -s -- -y\n",
+    "    !dgraph live -f ./data.rdf.gz --alpha {dgraph_hostname}:{dgraph_grpc_port} --zero {dgraph_hostname}:{dgraph_zero_port}\n",
+    "else:\n",
+    "    raise Exception(\"Unable to find a way to load data into your cluster.\")\n",
+    "\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install pydgraph\n",
+    "\n",
+    "!pip install pydgraph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize a pydgraph client\n",
+    "\n",
+    "import pydgraph\n",
+    "\n",
+    "client_stub = pydgraph.DgraphClientStub(addr=f\"{dgraph_hostname}:{dgraph_grpc_port}\", options=[('grpc.max_receive_message_length', 1024*1024*1024)])\n",
+    "pyd_client = pydgraph.DgraphClient(client_stub)\n",
+    "print(\"Dgraph Version:\", pyd_client.check_version())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perform a DQL query\n",
+    "\n",
+    "import json\n",
+    "\n",
+    "query = \"\"\"\n",
+    "{\n",
+    "  q(func: anyoftext(Record.name, \"living\"), first: 10) {\n",
+    "    id: Record.nodeID\n",
+    "    name: Record.name\n",
+    "  }\n",
+    "}\n",
+    "\"\"\"\n",
+    "res = pyd_client.txn(read_only=True).query(query)\n",
+    "print(json.dumps(json.loads(res.json), indent=2))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pydgraph/client_stub.py
+++ b/pydgraph/client_stub.py
@@ -87,6 +87,18 @@ class DgraphClientStub(object):
         del self.channel
         del self.stub
 
+    @staticmethod
+    def parse_host(cloud_endpoint):
+        """Converts any cloud endpoint to grpc endpoint"""
+        host = cloud_endpoint
+        if cloud_endpoint.startswith("http"): # catch http:// and https://
+            host = urlparse(cloud_endpoint).netloc
+        host = host.split(":",1)[0] # remove port if any
+        if not ".grpc." in host:
+            url_parts = host.split(".", 1)
+            host = url_parts[0] + ".grpc." + url_parts[1]
+        return host
+
     # accepts grpc endpoint as copied in cloud console as well as graphql endpoint
     # Usage:
     # import pydgraph
@@ -95,13 +107,7 @@ class DgraphClientStub(object):
     @staticmethod
     def from_cloud(cloud_endpoint, api_key):
         """Returns Dgraph Client stub for the Dgraph Cloud endpoint"""
-        if cloud_endpoint.startswith("http"): # catch http:// and https://
-            host = urlparse(cloud_endpoint).netloc
-        else:
-            host = cloud_endpoint.split(":",1)[0] # remove port if any
-        if not ".grpc." in host:
-            url_parts = host.split(".", 1)
-            host = url_parts[0] + ".grpc." + url_parts[1]
+        host = DgraphClientStub.parse_host(cloud_endpoint)
         creds = grpc.ssl_channel_credentials()
         call_credentials = grpc.metadata_call_credentials(
             lambda context, callback: callback((("authorization", api_key),), None))

--- a/tests/test_client_stub.py
+++ b/tests/test_client_stub.py
@@ -58,6 +58,7 @@ class TestFromCloud(unittest.TestCase):
         testcases = [
             {"endpoint": "godly.grpc.region.aws.cloud.dgraph.io"},
             {"endpoint": "godly.grpc.region.aws.cloud.dgraph.io:443"},
+            {"endpoint": "https://godly.grpc.region.aws.cloud.dgraph.io:443"},
             {"endpoint": "https://godly.region.aws.cloud.dgraph.io/graphql"},
             {"endpoint": "godly.region.aws.cloud.dgraph.io"},
             {"endpoint": "https://godly.region.aws.cloud.dgraph.io"},


### PR DESCRIPTION
This PR adds an Jupyter Notebook to the examples folder (capturing some learnings from the Knowledge Graph Conference).. Whilst testing a Dgraph Cloud version of the Notebook in this PR, I discovered a bug in the client_stub module whereby if both the protocol scheme (https) and the port number (:443) were included in the call to `from_cloud`, the connection would fail. This format was specifically illustrated in the README, so it was worth fixing. Although I did correct the example on the README to be the grpc endpoint value that is presented on the Dgraph Cloud Settings tab.

As mentioned, I attempted to add a Dgraph Cloud-specific Notebook, but data transfer quota issues are preventing me from testing that thoroughly (I opened a discussion in Slack), so this PR only includes a _self-managed_ cluster. That Notebook was tested on both a local Jupyter server as well as Google Colab.

I'll leave it to you @joshua-goldstein to whether you want to bump the official version and push to PyPI.
