### PR TITLE
CI: resolve failing jobs

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: "0 * * * *"
+    - cron: "1 0 * * *"
 jobs:
   build:
     name: trivy-tests

--- a/.github/workflows/ci-pydgraph-tests.yml
+++ b/.github/workflows/ci-pydgraph-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: "0 0 * * *" # run workflow daily
+    - cron: "1 0 * * *" # run workflow daily
 jobs:
   build:
     name: pydgraph-tests


### PR DESCRIPTION
scheduled runs are failing due to notifications being sent to non-existent email.  Changing cron frequency will reset this.