### PR TITLE
Allow flexible dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ classifiers=[
     'Topic :: Software Development',
     'Programming Language :: Python :: 3.11',
 ]
-dependencies = [ "grpcio==1.54.3", "protobuf==4.22.3" ]
+dependencies = [
+    "grpcio>=1.54.3,<2.0.0",
+    "protobuf>=4.22.3,<5.0.0"
+]
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
This pull request updates the dependency specifications for `grpcio` and `protobuf` to allow for minor and patch version flexibility.

Addresses https://github.com/dgraph-io/pydgraph/issues/222

### Changes

- Updated grpcio dependency from grpcio==1.54.0 to grpcio>=1.54.0,<2.0.0
- Updated protobuf dependency from protobuf==4.22.3 to protobuf>=4.22.3,<5.0.0

### Rationale

- **Flexibility**: This change allows the library to be compatible with a wider range of versions, making it easier to integrate into projects with different dependency requirements.
- **Compatibility**: Minor and patch versions are generally backward compatible. Allowing updates within these ranges enables the library to benefit from bug fixes and improvements.
- **Ease of Integration**: Reduces the likelihood of version conflicts, promoting smoother integration and wider adoption.