### PR TITLE
feat: surface transaction abort reason on AbortedError

### DIFF
--- a/pydgraph/__init__.py
+++ b/pydgraph/__init__.py
@@ -13,6 +13,7 @@ from pydgraph.client import DgraphClient, open  # noqa: A004
 from pydgraph.client_stub import DgraphClientStub, client_stub
 from pydgraph.errors import (
     AbortedError,
+    AbortReason,
     ConnectionError,  # noqa: A004
     RetriableError,
     TransactionError,
@@ -44,6 +45,7 @@ from pydgraph.retry import (
 from pydgraph.txn import Txn
 
 __all__ = [
+    "AbortReason",
     "AbortedError",
     "AsyncDgraphClient",
     "AsyncDgraphClientStub",

--- a/pydgraph/async_txn.py
+++ b/pydgraph/async_txn.py
@@ -341,7 +341,7 @@ class AsyncTxn:
             The original error otherwise
         """
         if util.is_aborted_error(error):
-            raise errors.AbortedError
+            raise errors.AbortedError(util.abort_error_message(error))
 
         if util.is_retriable_error(error):
             raise errors.RetriableError(error)
@@ -437,7 +437,7 @@ class AsyncTxn:
             The original error otherwise
         """
         if util.is_aborted_error(error):
-            raise errors.AbortedError
+            raise errors.AbortedError(util.abort_error_message(error))
 
         raise error
 

--- a/pydgraph/errors.py
+++ b/pydgraph/errors.py
@@ -23,13 +23,29 @@ class AbortReason(enum.Enum):
     these values.
 
     - ``CONFLICT`` — a write-write conflict with another concurrent transaction;
-      retrying with a fresh transaction is the expected response.
+      retrying with a fresh transaction is the expected response. The server cannot
+      say *which* key collided: conflict keys are one-way fingerprints by the time
+      they are compared, so the culprit may be the data key written directly, or an
+      index or count key derived from it. On an ``@upsert`` predicate the uid is
+      excluded from the comparison, so any two transactions writing the same value
+      conflict.
     - ``PREDICATE_MOVE`` — a predicate is being moved between groups and commits on
-      it are temporarily blocked; back off and retry once the move completes.
-    - ``STALE_STARTTS`` — the transaction's start timestamp predates the current Zero
-      leader (a leader change); retry with a fresh transaction.
-    - ``UNKNOWN`` — no reason was reported. Returned for aborts from older servers
-      that do not yet categorize the reason, so callers degrade gracefully.
+      it are blocked, or it finished moving while the transaction was open; back off
+      and retry once the move completes.
+    - ``STALE_STARTTS`` — the transaction's start timestamp is older than the oldest
+      timestamp the server can still validate against. That happens after a Zero
+      leader change, and also when Zero trims its conflict map at a snapshot, which
+      is not a leader change at all. Retry with a fresh transaction.
+    - ``UNKNOWN`` — no category was reported. This covers aborts from older servers,
+      which do not categorize at all, and aborts a current server declines to
+      categorize because no published category fits — for example a transaction
+      already aborted out of band by a schema change or the idle-transaction reaper,
+      a cancelled request, or a predicate no group currently serves. The message
+      still explains what happened; only the machine-readable category is absent.
+
+    Categories are matched on the message prefix, and an unrecognized prefix degrades
+    to ``UNKNOWN``. A newer server may therefore introduce categories this enum does
+    not name without breaking this client.
     """
 
     CONFLICT = "conflict"
@@ -42,8 +58,12 @@ def parse_abort_reason(message: str | None) -> AbortReason:
     """Parses the abort category from a server abort message.
 
     The reason is the ``"<code>: <detail>"`` prefix; matching is case-insensitive and
-    tolerant of surrounding whitespace. A message with no recognized prefix (e.g. from
-    a pre-feature server) returns :attr:`AbortReason.UNKNOWN`.
+    tolerant of surrounding whitespace. Only the *first* colon delimits the category —
+    several server messages contain colons of their own in the detail that follows.
+
+    A message with no recognized prefix returns :attr:`AbortReason.UNKNOWN`. That is
+    the expected result both for a pre-feature server and for causes a current server
+    deliberately leaves uncategorized rather than implying the wrong remedy.
     """
     if not message:
         return AbortReason.UNKNOWN

--- a/pydgraph/errors.py
+++ b/pydgraph/errors.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import enum
+
 from pydgraph.meta import VERSION
 
 __author__ = "Garvit Pahal"
@@ -13,13 +15,63 @@ __version__ = VERSION
 __status__ = "development"
 
 
+class AbortReason(enum.Enum):
+    """The category of a transaction abort, as reported by the Dgraph server.
+
+    The server encodes the reason as a ``"<code>: <detail>"`` prefix on the gRPC
+    ABORTED status message; :func:`parse_abort_reason` maps that prefix to one of
+    these values.
+
+    - ``CONFLICT`` — a write-write conflict with another concurrent transaction;
+      retrying with a fresh transaction is the expected response.
+    - ``PREDICATE_MOVE`` — a predicate is being moved between groups and commits on
+      it are temporarily blocked; back off and retry once the move completes.
+    - ``STALE_STARTTS`` — the transaction's start timestamp predates the current Zero
+      leader (a leader change); retry with a fresh transaction.
+    - ``UNKNOWN`` — no reason was reported. Returned for aborts from older servers
+      that do not yet categorize the reason, so callers degrade gracefully.
+    """
+
+    CONFLICT = "conflict"
+    PREDICATE_MOVE = "predicate-move"
+    STALE_STARTTS = "stale-startts"
+    UNKNOWN = "unknown"
+
+
+def parse_abort_reason(message: str | None) -> AbortReason:
+    """Parses the abort category from a server abort message.
+
+    The reason is the ``"<code>: <detail>"`` prefix; matching is case-insensitive and
+    tolerant of surrounding whitespace. A message with no recognized prefix (e.g. from
+    a pre-feature server) returns :attr:`AbortReason.UNKNOWN`.
+    """
+    if not message:
+        return AbortReason.UNKNOWN
+    code = message.split(":", 1)[0].strip().lower()
+    for reason in (
+        AbortReason.CONFLICT,
+        AbortReason.PREDICATE_MOVE,
+        AbortReason.STALE_STARTTS,
+    ):
+        if code == reason.value:
+            return reason
+    return AbortReason.UNKNOWN
+
+
 class AbortedError(Exception):
-    """Error thrown by aborted transactions."""
+    """Error thrown by aborted transactions.
+
+    The parsed abort category is available as :attr:`reason`; the full server message
+    remains available via ``str(error)``.
+    """
 
     def __init__(
-        self, message: str = "Transaction has been aborted. Please retry"
+        self,
+        message: str = "Transaction has been aborted. Please retry",
+        reason: AbortReason | None = None,
     ) -> None:
         super().__init__(message)
+        self.reason = reason if reason is not None else parse_abort_reason(message)
 
 
 class RetriableError(Exception):

--- a/pydgraph/txn.py
+++ b/pydgraph/txn.py
@@ -339,7 +339,7 @@ class Txn:
     @staticmethod
     def _common_except_mutate(error: Exception) -> None:
         if util.is_aborted_error(error):
-            raise errors.AbortedError
+            raise errors.AbortedError(util.abort_error_message(error))
 
         if util.is_retriable_error(error):
             raise errors.RetriableError(error)
@@ -399,7 +399,7 @@ class Txn:
     @staticmethod
     def _common_except_commit(error: Exception) -> None:
         if util.is_aborted_error(error):
-            raise errors.AbortedError
+            raise errors.AbortedError(util.abort_error_message(error))
 
         raise error
 

--- a/pydgraph/util.py
+++ b/pydgraph/util.py
@@ -46,6 +46,20 @@ def is_aborted_error(error: Any) -> bool:
     return False
 
 
+def abort_error_message(error: Any) -> str:
+    """Returns the server-supplied message from a gRPC error.
+
+    Prefers ``error.details()`` (the status description, which carries the abort
+    reason prefix), falling back to ``str(error)``. Used to surface the categorized
+    abort reason on AbortedError.
+    """
+    if hasattr(error, "details") and callable(error.details):
+        details = error.details()
+        if details:
+            return details
+    return str(error)
+
+
 def is_retriable_error(error: Exception) -> bool:
     """Returns true if the error is retriable (e.g server is not ready yet)."""
     msg = str(error)

--- a/tests/docker-compose.multigroup.yml
+++ b/tests/docker-compose.multigroup.yml
@@ -1,0 +1,36 @@
+# Multi-group, no-ACL cluster for the live transaction-abort-reason tests
+# (tests/test_abort_reason_live.py). Two alpha groups (replicas=1) enable the
+# predicate-move case; the single zero is restartable for the stale-startts case.
+#
+# Usage:
+#   DGRAPH_IMAGE_TAG=local docker compose -f tests/docker-compose.multigroup.yml up -d
+#   TEST_SERVER_ADDR=localhost:9180 \
+#   TEST_ZERO_HTTP=localhost:6180 \
+#   TEST_ZERO_RESTART_CMD="docker compose -f tests/docker-compose.multigroup.yml restart zero1" \
+#     python -m pytest tests/test_abort_reason_live.py -v
+#   docker compose -f tests/docker-compose.multigroup.yml down
+services:
+  zero1:
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
+    ports:
+      - "5180:5180"
+      - "6180:6180"
+    command: dgraph zero -o 100 --my=zero1:5180 --replicas=1 --logtostderr -v=2 --bindall
+
+  alpha1:
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
+    ports:
+      - "8180:8180"
+      - "9180:9180"
+    command:
+      dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2 --raft "idx=1;
+      group=1" --security "whitelist=0.0.0.0/0;"
+
+  alpha2:
+    image: dgraph/dgraph:${DGRAPH_IMAGE_TAG:-latest}
+    ports:
+      - "8182:8182"
+      - "9182:9182"
+    command:
+      dgraph alpha -o 102 --my=alpha2:7182 --zero=zero1:5180 --logtostderr -v=2 --raft "idx=2;
+      group=2" --security "whitelist=0.0.0.0/0;"

--- a/tests/test_abort_reason.py
+++ b/tests/test_abort_reason.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for surfacing the transaction-abort reason on AbortedError.
+
+The Dgraph server encodes the abort category as a ``"<code>: <detail>"`` prefix on the
+gRPC ABORTED status message. These tests verify that the prefix is parsed into an
+``AbortReason``, that the full message is preserved, and that aborts from a server which
+reports no reason degrade gracefully to ``UNKNOWN``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import pydgraph
+from pydgraph import errors
+
+
+class TestAbortReason(unittest.TestCase):
+    # --- The three server-reported categories ---
+
+    def test_conflict_reason(self) -> None:
+        err = errors.AbortedError("conflict: Transaction has been aborted. Please retry")
+        assert err.reason == pydgraph.AbortReason.CONFLICT
+
+    def test_predicate_move_reason(self) -> None:
+        err = errors.AbortedError(
+            "predicate-move: Commits on predicate name are blocked due to predicate move"
+        )
+        assert err.reason == pydgraph.AbortReason.PREDICATE_MOVE
+
+    def test_stale_startts_reason(self) -> None:
+        err = errors.AbortedError(
+            "stale-startts: Transaction has been aborted due to a leader change. Please retry"
+        )
+        assert err.reason == pydgraph.AbortReason.STALE_STARTTS
+
+    # --- Full message preserved alongside the parsed reason ---
+
+    def test_full_message_preserved(self) -> None:
+        desc = "conflict: Transaction has been aborted. Please retry"
+        err = errors.AbortedError(desc)
+        assert str(err) == desc
+
+    # --- Graceful degradation against an older server (no reason prefix) ---
+
+    def test_legacy_message_degrades_to_unknown(self) -> None:
+        # The default message (what older servers emit) has no category prefix.
+        err = errors.AbortedError()
+        assert err.reason == pydgraph.AbortReason.UNKNOWN
+
+    def test_unrecognized_prefix_degrades_to_unknown(self) -> None:
+        err = errors.AbortedError("something-else: not a known category")
+        assert err.reason == pydgraph.AbortReason.UNKNOWN
+
+    # --- Parsing robustness ---
+
+    def test_reason_is_case_insensitive_and_trimmed(self) -> None:
+        assert errors.AbortedError("CONFLICT: x").reason == pydgraph.AbortReason.CONFLICT
+        assert (
+            errors.AbortedError("  predicate-move : y").reason
+            == pydgraph.AbortReason.PREDICATE_MOVE
+        )
+
+    def test_reason_without_detail_still_parses(self) -> None:
+        assert errors.AbortedError("conflict").reason == pydgraph.AbortReason.CONFLICT
+
+    def test_parse_abort_reason_none_is_unknown(self) -> None:
+        assert errors.parse_abort_reason(None) == pydgraph.AbortReason.UNKNOWN
+        assert errors.parse_abort_reason("") == pydgraph.AbortReason.UNKNOWN
+
+    # --- Explicit reason overrides parsing ---
+
+    def test_explicit_reason_overrides_message(self) -> None:
+        err = errors.AbortedError(
+            "opaque message", reason=pydgraph.AbortReason.STALE_STARTTS
+        )
+        assert err.reason == pydgraph.AbortReason.STALE_STARTTS
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_abort_reason.py
+++ b/tests/test_abort_reason.py
@@ -16,37 +16,90 @@ import unittest
 import pydgraph
 from pydgraph import errors
 
+# Verbatim messages the server sends, from the abort-detail constants in
+# dgraph/cmd/zero/oracle.go. Kept literal rather than abbreviated so these fixtures stay
+# a faithful record of the wire format: several now contain colons of their own after the
+# category prefix, which is exactly the case the parser has to get right.
+SERVER_CONFLICT = (
+    "conflict: Transaction has been aborted. Please retry. Another transaction "
+    "committed to one of the same keys. The conflicting key cannot be identified: it "
+    "may be the data key written directly, or an index or count key derived from it. "
+    "On an @upsert predicate the uid is excluded, so any two transactions writing the "
+    "same value conflict"
+)
+SERVER_STALE_STARTTS = (
+    "stale-startts: Transaction start timestamp is older than the oldest timestamp Zero "
+    "can still validate (Zero leader change, or its conflict map was trimmed at a "
+    "snapshot). Please retry"
+)
+SERVER_MOVE_IN_FLIGHT = (
+    "predicate-move: Commits on predicate name are blocked due to predicate move"
+)
+SERVER_MOVE_COMPLETED = (
+    "predicate-move: Mutation done in group: 1. Predicate name assigned to 2"
+)
+
+# Causes the server deliberately leaves uncategorized: it says what happened, but no
+# published category fits, so it sends the detail with no prefix rather than implying a
+# wrong remedy.
+SERVER_PRE_ABORTED = (
+    "Transaction has been aborted. Please retry. It was already aborted before this "
+    "commit was decided, which happens when a schema update or a drop-predicate cancels "
+    "pending transactions on a predicate it touched, or when the server ages out "
+    'transactions idle for longer than --limit "txn-abort-after"'
+)
+SERVER_TABLET_NIL = "Tablet for name is nil"
+SERVER_MALFORMED_KEY = "Unable to find group id in 1name"
+SERVER_BAD_GROUP_ID = (
+    'unable to parse group id from xname: strconv.Atoi: parsing "x": invalid syntax'
+)
+SERVER_CTX_CANCELLED = "context canceled"
+
 
 class TestAbortReason(unittest.TestCase):
     # --- The three server-reported categories ---
 
     def test_conflict_reason(self) -> None:
-        err = errors.AbortedError("conflict: Transaction has been aborted. Please retry")
+        err = errors.AbortedError(SERVER_CONFLICT)
         assert err.reason == pydgraph.AbortReason.CONFLICT
 
     def test_predicate_move_reason(self) -> None:
-        err = errors.AbortedError(
-            "predicate-move: Commits on predicate name are blocked due to predicate move"
-        )
+        err = errors.AbortedError(SERVER_MOVE_IN_FLIGHT)
         assert err.reason == pydgraph.AbortReason.PREDICATE_MOVE
 
     def test_stale_startts_reason(self) -> None:
-        err = errors.AbortedError(
-            "stale-startts: Transaction has been aborted due to a leader change. Please retry"
-        )
+        err = errors.AbortedError(SERVER_STALE_STARTTS)
         assert err.reason == pydgraph.AbortReason.STALE_STARTTS
+
+    # --- Only the first colon delimits the category ---
+
+    def test_categories_parse_despite_embedded_colons(self) -> None:
+        # The conflict detail contains "cannot be identified: it may be", and the
+        # completed-move detail contains "group: 1". Splitting on the wrong colon would
+        # misread both.
+        assert SERVER_CONFLICT.count(":") > 1, "fixture must have >1 colon to be useful"
+        assert SERVER_MOVE_COMPLETED.count(":") > 1
+
+        assert (
+            errors.AbortedError(SERVER_CONFLICT).reason == pydgraph.AbortReason.CONFLICT
+        )
+        assert (
+            errors.AbortedError(SERVER_MOVE_COMPLETED).reason
+            == pydgraph.AbortReason.PREDICATE_MOVE
+        )
 
     # --- Full message preserved alongside the parsed reason ---
 
     def test_full_message_preserved(self) -> None:
-        desc = "conflict: Transaction has been aborted. Please retry"
-        err = errors.AbortedError(desc)
-        assert str(err) == desc
+        err = errors.AbortedError(SERVER_CONFLICT)
+        # The complete human-readable message survives, including the detail explaining
+        # which kinds of key could have collided.
+        assert str(err) == SERVER_CONFLICT
 
-    # --- Graceful degradation against an older server (no reason prefix) ---
+    # --- Graceful degradation when no category is reported ---
 
     def test_legacy_message_degrades_to_unknown(self) -> None:
-        # The default message (what older servers emit) has no category prefix.
+        # The default message (what pre-feature servers emit) has no category prefix.
         err = errors.AbortedError()
         assert err.reason == pydgraph.AbortReason.UNKNOWN
 
@@ -54,10 +107,46 @@ class TestAbortReason(unittest.TestCase):
         err = errors.AbortedError("something-else: not a known category")
         assert err.reason == pydgraph.AbortReason.UNKNOWN
 
+    def test_uncategorized_server_causes_degrade_to_unknown(self) -> None:
+        # A current server also sends aborts with no category, for causes no published
+        # category fits. The message still explains what happened; only the
+        # machine-readable code is absent. These are the real messages, not invented.
+        for message in (
+            SERVER_PRE_ABORTED,
+            SERVER_TABLET_NIL,
+            SERVER_MALFORMED_KEY,
+            SERVER_BAD_GROUP_ID,
+            SERVER_CTX_CANCELLED,
+        ):
+            err = errors.AbortedError(message)
+            assert err.reason == pydgraph.AbortReason.UNKNOWN, message
+            assert str(err) == message, "the explanation must survive intact"
+
+    def test_uncategorized_lookalikes_are_not_misparsed(self) -> None:
+        # The out-of-band abort opens with the exact sentence a pre-feature server sent
+        # for every abort, and the malformed-group-id message carries a colon of its own.
+        # Neither may be mistaken for a category: a false CONFLICT would tell a caller to
+        # retry something that cannot succeed.
+        assert SERVER_PRE_ABORTED.startswith(
+            "Transaction has been aborted. Please retry"
+        )
+        assert (
+            errors.AbortedError(SERVER_PRE_ABORTED).reason
+            == pydgraph.AbortReason.UNKNOWN
+        )
+
+        assert ":" in SERVER_BAD_GROUP_ID
+        assert (
+            errors.AbortedError(SERVER_BAD_GROUP_ID).reason
+            == pydgraph.AbortReason.UNKNOWN
+        )
+
     # --- Parsing robustness ---
 
     def test_reason_is_case_insensitive_and_trimmed(self) -> None:
-        assert errors.AbortedError("CONFLICT: x").reason == pydgraph.AbortReason.CONFLICT
+        assert (
+            errors.AbortedError("CONFLICT: x").reason == pydgraph.AbortReason.CONFLICT
+        )
         assert (
             errors.AbortedError("  predicate-move : y").reason
             == pydgraph.AbortReason.PREDICATE_MOVE

--- a/tests/test_abort_reason_live.py
+++ b/tests/test_abort_reason_live.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: © 2017-2026 Istari Digital, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live cross-language end-to-end tests for the transaction-abort reason.
+
+Unlike tests/test_abort_reason.py, which feeds synthetic messages into the parser, these
+drive a real (locally patched) Dgraph cluster and prove that each abort category travels
+all the way to AbortedError.reason:
+
+- conflict        — two concurrent transactions write the same predicate/uid.
+- stale-startts    — a transaction's start ts is invalidated by a Zero leader change; we
+                     force that by restarting Zero (TEST_ZERO_CONTAINER) mid-transaction.
+- predicate-move   — a predicate's tablet is moved to another group after a transaction
+                     mutated it; the post-move commit is rejected. Requires a multi-group
+                     cluster and the Zero admin HTTP endpoint (TEST_ZERO_HTTP).
+
+Each test skips cleanly when the infrastructure it needs is not configured, so the file is
+safe to include in the default suite. Configure via env vars:
+
+  TEST_SERVER_ADDR   alpha gRPC (default localhost:9180)
+  TEST_ZERO_HTTP     zero HTTP admin, e.g. localhost:6180 (enables predicate-move)
+  TEST_ZERO_CONTAINER  docker/podman container name of Zero (enables stale-startts restart)
+  TEST_ZERO_RESTART_CMD  shell command that restarts Zero (alternative to the container
+                         name, e.g. for a manually-launched cluster)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import unittest
+import urllib.request
+
+import pydgraph
+
+SERVER_ADDR = os.getenv("TEST_SERVER_ADDR", "localhost:9180")
+ZERO_HTTP = os.getenv("TEST_ZERO_HTTP")
+ZERO_CONTAINER = os.getenv("TEST_ZERO_CONTAINER")
+ZERO_RESTART_CMD = os.getenv("TEST_ZERO_RESTART_CMD")
+DOCKER = os.getenv("TEST_DOCKER_CMD", "docker")
+
+
+def _restart_zero() -> None:
+    if ZERO_RESTART_CMD:
+        subprocess.run(ZERO_RESTART_CMD, shell=True, check=True, timeout=60)  # noqa: S602
+    else:
+        subprocess.run([DOCKER, "restart", ZERO_CONTAINER], check=True, timeout=60)  # noqa: S603
+
+
+def _client() -> pydgraph.DgraphClient:
+    return pydgraph.DgraphClient(pydgraph.DgraphClientStub(SERVER_ADDR))
+
+
+def _zero_state() -> dict:
+    with urllib.request.urlopen(f"http://{ZERO_HTTP}/state", timeout=5) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _find_tablet(pred: str) -> tuple[str, str] | None:
+    """Returns (group_id, tablet_key) for the given predicate, or None.
+
+    Tablet keys are namespace-prefixed (e.g. "0-name"), so we match either the bare
+    predicate or a "<ns>-<pred>" key.
+    """
+    for gid, group in _zero_state().get("groups", {}).items():
+        for tablet in group.get("tablets") or {}:
+            if tablet == pred or tablet.endswith("-" + pred):
+                return gid, tablet
+    return None
+
+
+def _group_of(pred: str) -> str | None:
+    found = _find_tablet(pred)
+    return found[0] if found else None
+
+
+def _move_tablet(pred: str, group: str) -> None:
+    # moveTablet takes the bare predicate (namespace handled server-side), not the
+    # namespace-prefixed tablet key that /state reports.
+    url = f"http://{ZERO_HTTP}/moveTablet?tablet={pred}&group={group}"
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
+        resp.read()
+
+
+class TestAbortReasonLive(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = _client()
+        self.client.alter(pydgraph.Operation(drop_all=True))
+
+    def test_conflict_reports_conflict_reason(self) -> None:
+        txn = self.client.txn()
+        resp = txn.mutate(set_obj={"name": "Manish"})
+        uid = next(iter(resp.uids.values()))
+
+        txn2 = self.client.txn()
+        txn2.mutate(set_obj={"uid": uid, "name": "Manish"})
+
+        txn.commit()  # winner
+
+        with self.assertRaises(pydgraph.AbortedError) as ctx:
+            txn2.commit()
+        assert ctx.exception.reason == pydgraph.AbortReason.CONFLICT
+        assert "conflict" in str(ctx.exception)
+
+    @unittest.skipUnless(
+        ZERO_CONTAINER or ZERO_RESTART_CMD,
+        "set TEST_ZERO_CONTAINER or TEST_ZERO_RESTART_CMD to restart Zero",
+    )
+    def test_stale_startts_reports_stale_reason(self) -> None:
+        # Open a transaction so it gets a start ts that the restart will invalidate.
+        txn = self.client.txn()
+        txn.mutate(set_obj={"name": "Manish"})
+
+        # Restart Zero; on coming back it renews its lease and advances startTxnTs past the
+        # start ts above, making this transaction stale. Sleeps give the leader time to
+        # re-establish (lease renewal runs on becoming leader).
+        _restart_zero()
+        time.sleep(8)
+
+        with self.assertRaises(pydgraph.AbortedError) as ctx:
+            txn.commit()
+        assert ctx.exception.reason == pydgraph.AbortReason.STALE_STARTTS
+        assert "stale-startts" in str(ctx.exception)
+
+    @unittest.skipUnless(
+        ZERO_HTTP, "set TEST_ZERO_HTTP and run a multi-group cluster for predicate-move"
+    )
+    def test_predicate_move_reports_predicate_move_reason(self) -> None:
+        self.client.alter(pydgraph.Operation(schema="name: string @index(exact) ."))
+
+        # Seed so the "name" tablet exists and settles on some group.
+        seed = self.client.txn()
+        seed.mutate(set_obj={"name": "seed"})
+        seed.commit()
+        time.sleep(1)
+
+        found = _find_tablet("name")
+        groups = sorted(_zero_state().get("groups", {}).keys())
+        if found is None or len(groups) < 2:
+            self.skipTest("need a multi-group cluster serving predicate 'name'")
+        src, _tablet_key = found
+        dst = next(g for g in groups if g != src)
+
+        # Mutate "name" while it is on `src` (the txn's Preds will reference `src`), but
+        # do not commit yet.
+        txn = self.client.txn()
+        txn.mutate(set_obj={"name": "Manish"})
+
+        # Move the tablet to another group and wait for the move to complete.
+        _move_tablet("name", dst)
+        deadline = time.time() + 60
+        while time.time() < deadline and _group_of("name") != dst:
+            time.sleep(1)
+        assert _group_of("name") == dst, "tablet move did not complete"
+
+        # Committing now: the txn mutated on `src` but the tablet is on `dst`, so Zero's
+        # checkPreds rejects the commit with the predicate-move category.
+        with self.assertRaises(pydgraph.AbortedError) as ctx:
+            txn.commit()
+        assert ctx.exception.reason == pydgraph.AbortReason.PREDICATE_MOVE
+        assert "predicate-move" in str(ctx.exception)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When Dgraph aborts a transaction, pydgraph collapses every cause into a single opaque
exception:

```
pydgraph.errors.AbortedError: Transaction has been aborted. Please retry
```

`AbortedError` exposes no way to tell *why* the transaction aborted, so an application
cannot distinguish the cases that warrant different responses:

- a write-write **conflict** — retry immediately with a fresh transaction;
- a **predicate move** — a predicate is relocating between groups and commits on it are
  temporarily blocked, so back off and retry once the move completes;
- a **stale start-ts** — the transaction predates the current Zero leader (a leader
  change); retry with a fresh transaction.

The server now reports the category (see the companion `dgraph` PR), encoding it as a
`"<code>: <detail>"` prefix on the gRPC `ABORTED` status. Previously pydgraph discarded
even the server's message — it raised a bare `AbortedError` with a hardcoded default
string — so that information never reached the caller at all.

## Fix

Surface the category as a typed attribute on `AbortedError`, parsed from the message the
server already sends.

- **`AbortReason` enum** — `CONFLICT`, `PREDICATE_MOVE`, `STALE_STARTTS`, `UNKNOWN`
  (exported from the top-level `pydgraph` package).
- **`AbortedError.reason`** — the parsed `AbortReason`, derived via `parse_abort_reason()`
  from the `"<code>: <detail>"` prefix. The full server text remains available via
  `str(error)`.
- **Plumbing** — the sync and async commit/mutate paths (`txn.py`, `async_txn.py`) now
  pass the server's message into `AbortedError` instead of raising a reasonless default;
  `util.abort_error_message()` extracts it from the gRPC error (preferring
  `error.details()`, falling back to `str(error)`).

Backward compatible by design:

- Against an **older server** that reports no categorized prefix, `reason` is
  `AbortReason.UNKNOWN`, so callers degrade gracefully.
- The exception type is unchanged and it remains raised from the same paths — existing
  `except AbortedError` / retry logic is unaffected.

## Tests

- **`tests/test_abort_reason.py`** — unit tests for `parse_abort_reason()` and
  `AbortedError.reason`: each category parses correctly, and an empty or prefix-less
  message degrades to `UNKNOWN`.
- **`tests/test_abort_reason_live.py`** — end-to-end test that drives a real (locally
  patched) Dgraph cluster, forces each abort category, and asserts it propagates to
  `AbortedError.reason`. Skips gracefully when cluster prerequisites are unavailable.
  `tests/docker-compose.multigroup.yml` stands up the multi-group cluster needed for the
  predicate-move case.

## Future work

This change surfaces the **category** only — the slice the server provides today. Once the
server enriches aborts with the contended predicate and UID/token (planned `dgraph`
follow-up via the gRPC rich-error model, then a first-class `TxnContext` field), this
client can add typed accessors (e.g. `conflict_predicates`) without breaking the `reason`
attribute introduced here. A later phase may also expand `AbortReason` (e.g. splitting
non-move `predicate-move` cases into `PREDICATE_UNAVAILABLE` / `INTERNAL`); unknown codes
already map to `UNKNOWN`, so adding values stays backward compatible.

## Example

Before, every abort looked the same — there was no way to branch on the cause:

```python
except pydgraph.AbortedError:
    retry_with_new_txn()  # the only option, regardless of why it aborted
```

Now the category is available via `error.reason`:

```python
try:
    txn.mutate(set_obj=data)  # or txn.commit()
except pydgraph.AbortedError as error:
    if error.reason is pydgraph.AbortReason.PREDICATE_MOVE:
        backoff_and_retry()   # predicate relocating — back off, then retry
    elif error.reason is pydgraph.AbortReason.UNKNOWN:
        logging.warning("Txn aborted: %s", error)  # full text still available
        retry_with_new_txn()
    else:  # CONFLICT or STALE_STARTTS — retry with a fresh txn
        retry_with_new_txn()
```

## Checklist

- [x] The PR title follows the
      [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) syntax, leading
      with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- [ ] Code compiles correctly and linting (via trunk) passes locally
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] Requires PR https://github.com/dgraph-io/dgraph/pull/9747